### PR TITLE
First attempt at using the new search-interface on pd.info

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -207,13 +207,17 @@ proc ::deken::architecture_match {title} {
 # make a remote HTTP call and parse and display the results
 proc ::deken::search_for {term} {
     set searchresults [list]
-    set token [http::geturl "http://puredata.info/search_rss?SearchableText=$term+externals.zip&portal_type%3Alist=IAEMFile&portal_type%3Alist=PSCfile"]
+    #set token [http::geturl "http://puredata.info/search_rss?SearchableText=$term+externals.zip&portal_type%3Alist=IAEMFile&portal_type%3Alist=PSCfile"]
+    set token [http::geturl "http://puredata.info/dekenpackages?name=$term"]
     set contents [http::data $token]
     set splitCont [split $contents "\n"]
     # loop through the resulting XML parsing out entries containing results with a regular expression
     foreach ele $splitCont {
-        if {[regexp -- {<title>(.*?)</title>(.*?)<link>(.*?)</link>(.*?)<dc:creator>(.*?)</dc:creator>(.*?)<dc:date>(.*?)</dc:date>} $ele -> title junk URL junk creator junk date]} {
-            set result [list $title $URL $creator $date]
+	set ele [ string trim $ele ]
+	if { "" ne $ele } {
+	    set sele [ split $ele "\t" ]
+	    set result [list [ string trim [ lindex $sele 0 ]] [ string trim [ lindex $sele 1 ]] [ string trim [ lindex $sele 2 ]] [ string trim [ lindex $sele 0 ]]]
+            #set result [list $title $URL $creator $date]
             lappend searchresults $result
         }
     }


### PR DESCRIPTION
there's still a bug where packages don't show up if their 'title' doesn't match the deken-packagename.
example: zexy has some files with titles like 'W32 binaries'.
TODO: what to do with those packages anyhow? The user needs more info than just 'W32 binaries'. (e.g. they ought to see the library name somewhere)

Closes: https://github.com/pure-data/deken/issues/22