### PR TITLE
gpg fixes

### DIFF
--- a/deken.hy
+++ b/deken.hy
@@ -296,11 +296,9 @@
       (zipf.close)))
 
 ; upload a zipped up package to pure-data.info
-(defn upload-package [filepath]
+(defn upload-package [filepath username password]
   (let [
     ; get username and password from the environment, config, or user input
-    [username (or (get-config-value "username") (prompt-for-value "username"))]
-    [password (or (get-config-value "password") (prompt-for-value "password"))]
     [filename (os.path.basename filepath)]
     [destination (+ "/Members/" username "/" filename)]
     [dav (apply easywebdav.connect [externals-host] {"username" username "password" password})]]
@@ -383,12 +381,14 @@
       (if (args.repository.endswith ".zip")
         (do
           (print (+ "Uploading " args.repository))
+          (setv username (or (get-config-value "username") (prompt-for-value "username")))
+          (setv password (or (get-config-value "password") (getpass)))
           (hash-sum-file args.repository)
-          (upload-package (+ args.repository "." hash-extension))
-          (upload-package args.repository)
+          (upload-package (+ args.repository "." hash-extension) username password)
+          (upload-package args.repository username password)
           (let [[signed (gpg-sign-file args.repository)]]
             (if (= signed "signed")
-              (upload-package (+ args.repository ".asc")))))
+              (upload-package (+ args.repository ".asc") username password))))
         (do
           (print "Not an externals zipfile.")
           (sys.exit 1)))

--- a/deken.hy
+++ b/deken.hy
@@ -385,15 +385,18 @@
       ; user has asked to upload a zipfile
       (if (args.repository.endswith ".zip")
         (do
-          (print (+ "Uploading " args.repository))
-          (setv username (or (get-config-value "username") (prompt-for-value "username")))
-          (setv password (or (get-config-value "password") (getpass)))
-          (hash-sum-file args.repository)
-          (upload-package (+ args.repository "." hash-extension) username password)
-          (upload-package args.repository username password)
-          (let [[signed (gpg-sign-file args.repository)]]
-            (if signed
-              (upload-package signedfile username password))))
+         (print (+ "Uploading " args.repository))
+         (let [
+               [signedfile (gpg-sign-file args.repository)]
+               [username (or (get-config-value "username") (prompt-for-value "username"))]
+               [password (or (get-config-value "password") (getpass "Please enter password for uploading: "))]
+               ]
+           (do
+            (hash-sum-file args.repository)
+            (upload-package (+ args.repository "." hash-extension) username password)
+            (upload-package args.repository username password)
+            (if signedfile
+              (upload-package signedfile username password)))))
         (do
           (print "Not an externals zipfile.")
           (sys.exit 1)))

--- a/deken.hy
+++ b/deken.hy
@@ -479,4 +479,6 @@
           (command arguments))))
 
 (if (= __name__ "__main__")
-  (main))
+  (try
+   (main)
+   (catch [e KeyboardInterrupt] (print "\n[interrupted by user]"))))

--- a/deken.hy
+++ b/deken.hy
@@ -187,9 +187,10 @@
           (if (len buf) (do
             (hashfn.update buf)
             (recur (read-chunk)))))
-    (let [[digest (hashfn.hexdigest)]]
-      (.write (file (+ filename (% ".%s" hash-extension)) "wb") digest)
-      digest)))
+    (let [[digest (hashfn.hexdigest)]
+          [hashfilename (% "%s.%s" (tuple [filename hash-extension]))]]
+      (.write (file hashfilename "wb") digest)
+      hashfilename)))
 
 ; generate a GPG signature for a particular file
 (defn gpg-sign-file [filename]
@@ -388,12 +389,12 @@
          (print (+ "Uploading " args.repository))
          (let [
                [signedfile (gpg-sign-file args.repository)]
+               [hashfile   (hash-sum-file args.repository)]
                [username (or (get-config-value "username") (prompt-for-value "username"))]
                [password (or (get-config-value "password") (getpass "Please enter password for uploading: "))]
                ]
            (do
-            (hash-sum-file args.repository)
-            (upload-package (+ args.repository "." hash-extension) username password)
+            (upload-package hashfile username password)
             (upload-package args.repository username password)
             (if signedfile
               (upload-package signedfile username password)))))


### PR DESCRIPTION
this patchset deals with:
- streamlining the flow: first ask for credentials (and do that only once), then sign and upload
- fix the "key_id" configuration (and try to guess the default-key if that is not present)
- catch KeyboardInterrupt for a nicer error message (not related to gpg)