### PR TITLE
Issue11: arbitrary destination

### DIFF
--- a/deken.hy
+++ b/deken.hy
@@ -359,7 +359,7 @@
   (let [
     ; get username and password from the environment, config, or user input
     [filename (os.path.basename filepath)]
-    [[proto host path] (parse-url destination "http" externals-host (+ "/Members/" username))]
+    [[proto host path] (parse-url destination "https" externals-host (+ "/Members/" username))]
     [remotepath (+ path "/" filename)]
     [url (+ proto "://" host path)]
     [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]

--- a/deken.hy
+++ b/deken.hy
@@ -354,7 +354,7 @@
     [url (urlparse destination)]
     [proto (or url.scheme "https")]
     [host (or url.netloc externals-host)]
-    [path (or url.path (+ "/Members/" username))]
+    [path (if (= url "") (+ "/Members/" username "/software") (str url.path) )]
     [remotepath (+ path "/" filename)]
     [url (+ proto "://" host path)]
     [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]

--- a/deken.hy
+++ b/deken.hy
@@ -358,15 +358,18 @@
   (let [
     ; get username and password from the environment, config, or user input
     [filename (os.path.basename filepath)]
-    [dav (apply easywebdav.connect [externals-host] {"username" username "password" password})]]
-      (print (+ "Uploading " filename " to http://" externals-host destination))
+    [[proto host path] (parse-url destination "http" externals-host (+ "/Members" username))]
+    [remotepath (+ path "/" filename)]
+    [url (+ proto "://" host "/" destination)]
+    [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]
+      (print (+ "Uploading " filename " to " url))
       (try
         ; upload the package file
-        (dav.upload filepath destination)
+        (dav.upload filepath remotepath)
         (catch [e easywebdav.client.OperationFailed]
-          (print (+ "Couldn't upload to http://" externals-host destination))
-          (print (% "Are you sure you have the correct username and password set for <http://%s/>?" externals-host))
-          (print (% "Please ensure the folder %s exists and is writeable." destination))
+          (print (+ "Couldn't upload to " url))
+          (print (% "Are you sure you have the correct username and password set for '%s'?" host))
+          (print (% "Please ensure the folder %s exists and is writeable." path))
           (sys.exit 1)))))
 
 ; get the name of the external from the repository path

--- a/deken.hy
+++ b/deken.hy
@@ -361,7 +361,7 @@
     [filename (os.path.basename filepath)]
     [[proto host path] (parse-url destination "http" externals-host (+ "/Members" username))]
     [remotepath (+ path "/" filename)]
-    [url (+ proto "://" host "/" destination)]
+    [url (+ proto "://" host path)]
     [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]
       (print (+ "Uploading " filename " to " url))
       (try
@@ -370,7 +370,7 @@
         (catch [e easywebdav.client.OperationFailed]
           (print (+ "Couldn't upload to " url))
           (print (% "Are you sure you have the correct username and password set for '%s'?" host))
-          (print (% "Please ensure the folder %s exists and is writeable." path))
+          (print (% "Please ensure the folder '%s' exists and is writeable." path))
           (sys.exit 1)))))
 
 ; get the name of the external from the repository path

--- a/deken.hy
+++ b/deken.hy
@@ -345,6 +345,14 @@
               [(.endswith FNAME ".tgz") True]
               [True False])))
 
+; try to parse a URL into proto://host/path
+(defn parse-url [URL proto host path]
+  (if URL (do
+           (import re)
+           (try (setv [_ proto host path _] (re.split "^(https?)://([^/]*)(/.*)" URL))
+                (catch [e ValueError] (setv path URL)))))
+  [proto host (.strip path "/")])
+
 ; upload a zipped up package to pure-data.info
 (defn upload-package [filepath destination username password]
   (let [

--- a/deken.hy
+++ b/deken.hy
@@ -350,8 +350,9 @@
   (if URL (do
            (import re)
            (try (setv [_ proto host path _] (re.split "^(https?)://([^/]*)(/.*)" URL))
-                (catch [e ValueError] (setv path URL)))))
-  [proto host (.strip path "/")])
+                (catch [e ValueError] (try (setv [_ proto host _] (re.split "^(https?)://(.*)" URL))
+                                           (catch [e ValueError] (setv path URL)))))))
+  [proto (.strip host "/") (+ "/" (.strip path "/"))])
 
 ; upload a zipped up package to pure-data.info
 (defn upload-package [filepath destination username password]

--- a/deken.hy
+++ b/deken.hy
@@ -365,10 +365,11 @@
     [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]
       (print (+ "Uploading " filename " to " url))
       (try
-        ; make sure all directories exist
-        (dav.mkdirs path)
-        ; upload the package file
-        (dav.upload filepath remotepath)
+        (do
+          ; make sure all directories exist
+          (dav.mkdirs path)
+          ; upload the package file
+          (dav.upload filepath remotepath))
         (catch [e easywebdav.client.OperationFailed]
           (print (+ "Couldn't upload to " url))
           (print (% "Are you sure you have the correct username and password set for '%s'?" host))

--- a/deken.hy
+++ b/deken.hy
@@ -354,7 +354,7 @@
     [url (urlparse destination)]
     [proto (or url.scheme "https")]
     [host (or url.netloc externals-host)]
-    [path (if (= url "") (+ "/Members/" username "/software") (str url.path) )]
+    [path (if (= destination "") (+ "/Members/" username "/software") (str url.path) )]
     [remotepath (+ path "/" filename)]
     [url (+ proto "://" host path)]
     [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]

--- a/deken.hy
+++ b/deken.hy
@@ -359,7 +359,7 @@
   (let [
     ; get username and password from the environment, config, or user input
     [filename (os.path.basename filepath)]
-    [[proto host path] (parse-url destination "http" externals-host (+ "/Members" username))]
+    [[proto host path] (parse-url destination "http" externals-host (+ "/Members/" username))]
     [remotepath (+ path "/" filename)]
     [url (+ proto "://" host path)]
     [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]
@@ -445,7 +445,7 @@
                [hashfile   (hash-sum-file args.repository)]
                [username (or (get-config-value "username") (prompt-for-value "username"))]
                [password (or (get-config-value "password") (getpass "Please enter password for uploading: "))]
-               [destination (or (getattr args "destination") (+ "/Members/" username "/" filename))]]
+               [destination (getattr args "destination")]]
            (do
             (upload-package hashfile destination username password)
             (upload-package args.repository destination username password)

--- a/deken.hy
+++ b/deken.hy
@@ -445,7 +445,7 @@
                [hashfile   (hash-sum-file args.repository)]
                [username (or (get-config-value "username") (prompt-for-value "username"))]
                [password (or (get-config-value "password") (getpass "Please enter password for uploading: "))]
-               [destination (getattr args "destination")]]
+               [destination (or (getattr args "destination") (get-config-value "destination" ""))]]
            (do
             (upload-package hashfile destination username password)
             (upload-package args.repository destination username password)

--- a/deken.hy
+++ b/deken.hy
@@ -365,6 +365,8 @@
     [dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto})]]
       (print (+ "Uploading " filename " to " url))
       (try
+        ; make sure all directories exist
+        (dav.mkdirs path)
         ; upload the package file
         (dav.upload filepath remotepath)
         (catch [e easywebdav.client.OperationFailed]


### PR DESCRIPTION
the new patch set allows to set full URLs as destination: so we can push to any webdav(s) enabled host, not just puredata.info.

it also fixes the upload-to-folder problem (by appending the filename)