### PR TITLE
document search-all feature

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -82,7 +82,9 @@ proc ::deken::clearpost {} {
     variable mytoplevelref
     $mytoplevelref.results delete 1.0 end
 }
-proc ::deken::bindtag {} {
+proc ::deken::bind_posttag {tag key cmd} {
+    variable mytoplevelref
+    $mytoplevelref.results tag bind $tag $key $cmd
 
 }
 
@@ -182,15 +184,15 @@ proc ::deken::show_result {mytoplevel counter result showmatches} {
             set readable_date [regsub -all {[TZ]} $date { }]
             if {($archmatch == $showmatches)} {
                 ::deken::post "$title\n\tUploaded by $creator $readable_date\n" $tag
-                $mytoplevel.results tag bind $tag <Enter> "$mytoplevel.results tag configure $tag -foreground blue; ::deken::status $URL"
+                ::deken::bind_posttag $tag <Enter> "$mytoplevel.results tag configure $tag -foreground blue; ::deken::status $URL"
                 # have to decode the URL here because otherwise percent signs cause tcl to bug out - not sure why - scripting languages...
-                $mytoplevel.results tag bind $tag <1> [list ::deken::clicked_link $mytoplevel [urldecode $URL] $filename]
+                ::deken::bind_posttag $tag <l> [list ::deken::clicked_link $mytoplevel [urldecode $URL] $filename]
             }
             if {($archmatch == 1) && ($showmatches == 1)} {
-                $mytoplevel.results tag bind $tag <Leave> "$mytoplevel.results tag configure $tag -foreground black"
+                ::deken::bind_posttag $tag <Leave> "$mytoplevel.results tag configure $tag -foreground black"
                 $mytoplevel.results tag configure $tag -foreground black
             } elseif {($archmatch == 0) && ($showmatches == 0)} {
-                $mytoplevel.results tag bind $tag <Leave> "$mytoplevel.results tag configure $tag -foreground gray"
+                ::deken::bind_posttag $tag <Leave> "$mytoplevel.results tag configure $tag -foreground gray"
                 $mytoplevel.results tag configure $tag -foreground gray
             }
 }

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -95,6 +95,13 @@ proc ::deken::highlightable_posttag {tag} {
     # make sure that the 'highlight' tag is topmost
     $mytoplevelref.results tag raise highlight
 }
+proc ::deken::update_searchbutton {mytoplevel} {
+    if { [$mytoplevel.searchbit.entry get] == "" } {
+        $mytoplevel.searchbit.button configure -text [_ "Show all" ]
+    } {
+        $mytoplevel.searchbit.button configure -text [_ "Search" ]
+    }
+}
 
 # this function gets called when the menu is clicked
 proc ::deken::open_searchui {mytoplevel} {
@@ -133,6 +140,7 @@ proc ::deken::create_dialog {mytoplevel} {
     entry $mytoplevel.searchbit.entry -font 18 -relief sunken -highlightthickness 1 -highlightcolor blue
     pack $mytoplevel.searchbit.entry -side left -padx 6 -fill x -expand true
     bind $mytoplevel.searchbit.entry <Key-Return> "::deken::initiate_search $mytoplevel"
+    bind $mytoplevel.searchbit.entry <KeyRelease> "::deken::update_searchbutton $mytoplevel"
     focus $mytoplevel.searchbit.entry
 
     frame $mytoplevel.warning
@@ -145,7 +153,7 @@ proc ::deken::create_dialog {mytoplevel} {
     label $mytoplevel.status.label -textvariable ::deken::statustext
     pack $mytoplevel.status.label -side left -padx 6
 
-    button $mytoplevel.searchbit.button -text [_ "Search"] -default active -width 9 -command "::deken::initiate_search $mytoplevel"
+    button $mytoplevel.searchbit.button -text [_ "Show all"] -default active -width 9 -command "::deken::initiate_search $mytoplevel"
     pack $mytoplevel.searchbit.button -side right -padx 6 -pady 3
 
     text $mytoplevel.results -takefocus 0 -cursor hand2 -height 100 -yscrollcommand "$mytoplevel.results.ys set"

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -104,11 +104,13 @@ proc ::deken::open_searchui {mytoplevel} {
     } else {
         create_dialog $mytoplevel
         $mytoplevel.results tag configure warn -foreground orange
+        $mytoplevel.results tag configure info -foreground grey
         $mytoplevel.results tag configure highlight -foreground blue
         $mytoplevel.results tag configure archmatch -foreground black
         $mytoplevel.results tag configure noarchmatch -foreground grey
     }
     #search_for "freeverb" $mytoplevel.f.resultstext
+    ::deken::post "To get a list of all available externals, try an empty search." info
 }
 
 # build the externals search dialog window


### PR DESCRIPTION
apart from making the search-all feature more prominent (by changing the button title and displaying a short help-message), this branch 

- revamps the output to the deken-window, by providing ::deken::post proc
- re-implements the mouse-over highlighting code so it doesn't need to be implemented explicitely for each text-chunk