### PR TITLE
fix bashisms

### DIFF
--- a/deken
+++ b/deken
@@ -62,9 +62,9 @@ install_virtualenv {
 	tar -zxvf $DEKEN_HOME/virtualenv.tar.gz -C $DEKEN_HOME/virtualenv-source/ && \
 	mv $DEKEN_HOME/virtualenv-source/virtualenv-*/* $DEKEN_HOME/virtualenv-source
 	[ -d "$DEKEN_HOME/virtualenv-source" ] && (\
-		pushd $DEKEN_HOME/virtualenv-source && \
-		/usr/bin/env python setup.py build && \
-		popd ) || bail_install;
+		cd $DEKEN_HOME/virtualenv-source && \
+		/usr/bin/env python setup.py build ) \
+		|| bail_install;
 }
 
 install_deken {

--- a/deken
+++ b/deken
@@ -46,8 +46,13 @@ if $cygwin; then
     export DEKEN_HOME=$(cygpath -w "$DEKEN_HOME")
 fi
 
+error {
+    echo "$@" 1>&2
+}
+
 bail_install {
-    echo "Self-installation of Deken failed. Please paste any errors in the bug tracker at https://github.com/pure-data/deken/issues"
+    error "Self-installation of Deken failed."
+    error "Please paste any errors in the bug tracker at https://github.com/pure-data/deken/issues"
     # remove all trace of our attempts to install.
     rm -rf $DEKEN_HOME;
     # bail from this script.
@@ -69,12 +74,12 @@ install_virtualenv {
 
 install_deken {
     which python >/dev/null && \
-        echo "Oops, no Python found! You need Python to run Deken." && bail_install;
+        error "Oops, no Python found! You need Python to run Deken." && bail_install;
     which make >/dev/null && \
-        echo "Oops, no Make found! You need Make to run Deken." && bail_install;
-    echo "This is your first time running deken on this machine."
-    echo "I'm going to install myself and my dependencies into ~/.deken now."
-    echo "Feel free to ctrl-C now if you don't want to do this."
+        error "Oops, no Make found! You need Make to run Deken." && bail_install;
+    error "This is your first time running deken on this machine."
+    error "I'm going to install myself and my dependencies into ~/.deken now."
+    error "Feel free to ctrl-C now if you don't want to do this."
     sleep 3;
     [ -d "$DEKEN_HOME" ] || mkdir -p $DEKEN_HOME;
     [ -e "$DEKEN_HOME/requirements.txt" ] || (\
@@ -102,7 +107,7 @@ upgrade_deken {
     for f in requirements.txt deken.hy;
     do
         echo "Fetching $f file: $DEKEN_BASE_URL/$f";
-        $HTTP_CLIENT $DEKEN_HOME/.upgrade-$f $DEKEN_BASE_URL/$f || ( echo "Error upgrading $f"; exit 1; );
+        $HTTP_CLIENT $DEKEN_HOME/.upgrade-$f $DEKEN_BASE_URL/$f || ( error "Error upgrading $f"; exit 1; );
         mv $DEKEN_HOME/.upgrade-$f $DEKEN_HOME/$f;
     done
     # finally update the python dependencies

--- a/deken
+++ b/deken
@@ -96,8 +96,8 @@ install_deken {
 
 upgrade_deken {
     # first upgrade this script itself
-    echo "Upgrading $BASH_SOURCE."
-    $HTTP_CLIENT $BASH_SOURCE $DEKEN_BASE_URL/deken
+    echo "Upgrading $0."
+    $HTTP_CLIENT $0 $DEKEN_BASE_URL/deken
     # next upgrade our dependencies
     for f in requirements.txt deken.hy;
     do

--- a/deken
+++ b/deken
@@ -29,7 +29,7 @@ fi
 
 # This needs to be defined before we call HTTP_CLIENT below
 if [ "$HTTP_CLIENT" = "" ]; then
-    if type -p curl >/dev/null 2>&1; then
+    if which curl >/dev/null; then
         if [ "$https_proxy" != "" ]; then
             CURL_PROXY="-x $https_proxy"
         fi
@@ -72,9 +72,9 @@ install_deken {
     echo "I'm going to install myself and my dependencies into ~/.deken now."
     echo "Feel free to ctrl-C now if you don't want to do this."
     sleep 3;
-    [ "" = "$(which python)" ] && \
+    which python >/dev/null && \
         echo "Oops, no Python found! You need Python to run Deken." && bail_install;
-    [ "" = "$(which make)" ] && \
+    which make >/dev/null && \
         echo "Oops, no Make found! You need Make to run Deken." && bail_install;
     [ -d "$DEKEN_HOME" ] || mkdir -p $DEKEN_HOME;
     [ -e "$DEKEN_HOME/requirements.txt" ] || (\

--- a/deken
+++ b/deken
@@ -15,13 +15,13 @@ if [ `id -u` -eq 0 ] && [ "$DEKEN_ROOT" = "" ]; then
     read _
 fi
 
-if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
+if [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "msys" ]; then
     delimiter=";"
 else
     delimiter=":"
 fi
 
-if [[ "$OSTYPE" == "cygwin" ]]; then
+if [ "$OSTYPE" = "cygwin" ]; then
   cygwin=true
 else
   cygwin=false
@@ -72,9 +72,9 @@ install_deken {
     echo "I'm going to install myself and my dependencies into ~/.deken now."
     echo "Feel free to ctrl-C now if you don't want to do this."
     sleep 3;
-    [ "" == "`which python`" ] && \
+    [ "" = "`which python`" ] && \
         echo "Oops, no Python found! You need Python to run Deken." && bail_install;
-    [ "" == "`which make`" ] && \
+    [ "" = "`which make`" ] && \
         echo "Oops, no Make found! You need Make to run Deken." && bail_install;
     [ -d "$DEKEN_HOME" ] || mkdir -p $DEKEN_HOME;
     [ -e "$DEKEN_HOME/requirements.txt" ] || (\
@@ -117,7 +117,7 @@ upgrade_deken {
 [ -d "$DEKEN_HOME" ] || bail_install;
 
 # catch the special "upgrade" command
-[ "$1" == "upgrade" ] && \
+[ "$1" = "upgrade" ] && \
     # run he upgrade command instead
     upgrade_deken || \
     # run the real deken command with args passed through

--- a/deken
+++ b/deken
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-# Ensure this file is executable via $(chmod a+x deken), then place it
+# Ensure this file is executable via `chmod a+x deken`, then place it
 # somewhere on your $PATH, like ~/bin. The rest of Deken will self-install
 # on first run into the ~/.deken/ directory.
 

--- a/deken
+++ b/deken
@@ -46,7 +46,7 @@ if $cygwin; then
     export DEKEN_HOME=`cygpath -w "$DEKEN_HOME"`
 fi
 
-function bail_install {
+bail_install {
     echo "Self-installation of Deken failed. Please paste any errors in the bug tracker at https://github.com/pure-data/deken/issues"
     # remove all trace of our attempts to install.
     rm -rf $DEKEN_HOME;
@@ -54,7 +54,7 @@ function bail_install {
     exit 1;
 }
 
-function install_virtualenv {
+install_virtualenv {
 	echo "Downloading & installing Virtualenv."
 	rm -rf $DEKEN_HOME/virtualenv-source
 	mkdir -p $DEKEN_HOME/virtualenv-source && \
@@ -67,7 +67,7 @@ function install_virtualenv {
 		popd ) || bail_install;
 }
 
-function install_deken {
+install_deken {
     echo "This is your first time running deken on this machine."
     echo "I'm going to install myself and my dependencies into ~/.deken now."
     echo "Feel free to ctrl-C now if you don't want to do this."
@@ -94,7 +94,7 @@ function install_deken {
         $DEKEN_HOME/virtualenv/bin/pip install -r $DEKEN_HOME/requirements.txt || exit 1)
 }
 
-function upgrade_deken {
+upgrade_deken {
     # first upgrade this script itself
     echo "Upgrading $BASH_SOURCE."
     $HTTP_CLIENT $BASH_SOURCE $DEKEN_BASE_URL/deken

--- a/deken
+++ b/deken
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Ensure this file is executable via `chmod a+x deken`, then place it
+# Ensure this file is executable via $(chmod a+x deken), then place it
 # somewhere on your $PATH, like ~/bin. The rest of Deken will self-install
 # on first run into the ~/.deken/ directory.
 
@@ -8,7 +8,7 @@
 
 export DEKEN_VERSION="0.1"
 
-if [ `id -u` -eq 0 ] && [ "$DEKEN_ROOT" = "" ]; then
+if [ $(id -u) -eq 0 ] && [ "$DEKEN_ROOT" = "" ]; then
     echo "WARNING: You're currently running as root; probably by accident."
     echo "Press control-C to abort or Enter to continue as root."
     echo "Set DEKEN_ROOT to disable this warning."
@@ -43,7 +43,7 @@ export DEKEN_HOME="${DEKEN_HOME:-"$HOME/.deken"}"
 DEKEN_BASE_URL="https://raw.githubusercontent.com/pure-data/deken/master"
 
 if $cygwin; then
-    export DEKEN_HOME=`cygpath -w "$DEKEN_HOME"`
+    export DEKEN_HOME=$(cygpath -w "$DEKEN_HOME")
 fi
 
 bail_install {
@@ -72,9 +72,9 @@ install_deken {
     echo "I'm going to install myself and my dependencies into ~/.deken now."
     echo "Feel free to ctrl-C now if you don't want to do this."
     sleep 3;
-    [ "" = "`which python`" ] && \
+    [ "" = "$(which python)" ] && \
         echo "Oops, no Python found! You need Python to run Deken." && bail_install;
-    [ "" = "`which make`" ] && \
+    [ "" = "$(which make)" ] && \
         echo "Oops, no Make found! You need Make to run Deken." && bail_install;
     [ -d "$DEKEN_HOME" ] || mkdir -p $DEKEN_HOME;
     [ -e "$DEKEN_HOME/requirements.txt" ] || (\

--- a/deken
+++ b/deken
@@ -68,14 +68,14 @@ install_virtualenv {
 }
 
 install_deken {
-    echo "This is your first time running deken on this machine."
-    echo "I'm going to install myself and my dependencies into ~/.deken now."
-    echo "Feel free to ctrl-C now if you don't want to do this."
-    sleep 3;
     which python >/dev/null && \
         echo "Oops, no Python found! You need Python to run Deken." && bail_install;
     which make >/dev/null && \
         echo "Oops, no Make found! You need Make to run Deken." && bail_install;
+    echo "This is your first time running deken on this machine."
+    echo "I'm going to install myself and my dependencies into ~/.deken now."
+    echo "Feel free to ctrl-C now if you don't want to do this."
+    sleep 3;
     [ -d "$DEKEN_HOME" ] || mkdir -p $DEKEN_HOME;
     [ -e "$DEKEN_HOME/requirements.txt" ] || (\
         ( echo "Fetching Python requirements file: $DEKEN_BASE_URL/requirements.txt" && \


### PR DESCRIPTION
this patch set tries to get rid of the most staring bashisms in the `deken` script.

unresolved issues: `${OSTYPE}` is only available on bash. (since it is only used to detect cygwin/msys, and w32 is special anyhow, i guess we can live with that)