### PR TITLE
securing passwords (gpg and upload)

### DIFF
--- a/deken.hy
+++ b/deken.hy
@@ -453,9 +453,10 @@
     ; are they asking the package a directory or an existing repository?
     (if (os.path.isdir args.repository)
       ; if asking for a directory just package it up
-      (let [[package-filename (make-archive-basename args.repository args.version)]]
-        (print "Packaging into" package-filename)
-        (archive-dir args.repository package-filename))
+      (let [[package-filename (make-archive-basename args.repository args.version)]
+            [_ (print "Packaging into" package-filename)]
+            [archive-filename (archive-dir args.repository package-filename)]]
+        (gpg-sign-file archive-filename))
       ; otherwise build and then package
       (let [
         [external-name (get-external-name args.repository)]
@@ -465,7 +466,8 @@
           ((:build commands) args)
           (install-one build-folder externals-packaging-path)
           (print "Build-Packaging into" package-filename)
-          (archive-dir package-folder package-filename))))
+          (archive-dir package-folder package-filename)
+          (gpg-sign-file package-filename))))
   ; upload packaged external to pure-data.info
   :upload (fn [args]
     (if (os.path.isfile args.repository)

--- a/deken.hy
+++ b/deken.hy
@@ -169,10 +169,13 @@
 
 ; try to obtain a value from environment, then config file, then prompt user
 (defn get-config-value [name &rest default]
-  (or
-    (os.environ.get (+ "DEKEN_" (name.upper)))
-    (config.get name)
-    (and default (get default 0))))
+   (first (filter (fn [x] (not (nil? x))) [
+     ; try to get the value from an environment variable
+     (os.environ.get (+ "DEKEN_" (name.upper)))
+     ; try to get the value from the config file
+     (config.get name)
+     ; finally, try the default
+     (first default)])))
 
 ; prompt for a particular config value for externals host upload
 (defn prompt-for-value [name]

--- a/deken.hy
+++ b/deken.hy
@@ -455,7 +455,7 @@
          (let [[signedfile (gpg-sign-file args.repository)]
                [hashfile   (hash-sum-file args.repository)]
                [username (or (get-config-value "username") (prompt-for-value "username"))]
-               [password (or (get-config-value "password") (getpass "Please enter password for uploading: "))]
+               [password (get-upload-password username args.ask-password)]
                [destination (or (getattr args "destination") (get-config-value "destination" ""))]]
            (do
             (upload-package hashfile destination username password)

--- a/deken.hy
+++ b/deken.hy
@@ -214,8 +214,8 @@
      (catch [e IndexError] None))))
 
 ; generate a GPG signature for a particular file
-(defn gpg-sign-file [filename]
-  (print "Attempting to GPG sign" filename)
+(defn do-gpg-sign-file [filename signfile]
+  (print (% "Attempting to GPG sign '%s'" filename))
   (let [[gnupghome (get-config-value "gpg_home")]
         [use-agent (str-to-bool (get-config-value "gpg_agent"))]
         [gpgconfig {}]
@@ -250,6 +250,14 @@
        (do
         (.write (file signfile "wb") (str sig))
         signfile)))))
+; sign a file if it is not already signed
+(defn gpg-sign-file [filename]
+  (let [[signfile (+ filename ".asc")]]
+    (if (os.path.exists signfile)
+      (do
+       (print (% "NOTICE: not GPG-signing already signed file '%s'\nNOTICE: delete '%s' to re-sign" (, filename signfile)))
+       signfile)
+      (do-gpg-sign-file filename signfile))))
 
 ; get access to a command line binary in a way that checks for it's existence and reacts to errors correctly
 (defn get-binary [binary-name]

--- a/deken.hy
+++ b/deken.hy
@@ -78,6 +78,9 @@
 ; convet a string into bool, based on the string value
 (defn str-to-bool [s] (and (not (nil? s)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
 
+; concatenate two dictionaries - hylang's assoc is broken
+(defn dict-merge [d1 d2] (apply dict [d1] (or d2 {})))
+
 ; read in the config file if present
 (def config
   (let [

--- a/deken.hy
+++ b/deken.hy
@@ -496,6 +496,7 @@
       (apply arg-upload.add_argument ["repository"] {"help" "Either the path to an external zipfile to be uploaded, or the SVN or git repository of an external to package."})
       (apply arg-upload.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name." "default" "" "required" false})
       (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the file into (defaults to /Members/USER/)." "default" "" "required" false})
+      (apply arg-upload.add_argument ["--ask-password" "-P"] {"action" "store_true" "help" "Ask for upload password (rather than using password-manager." "default" "" "required" false})
       (apply arg-pd.add_argument ["version"] {"help" "Fetch a particular version of Pd to build against." "nargs" "?"})
       (let [
         [arguments (.parse_args arg-parser)]

--- a/deken.hy
+++ b/deken.hy
@@ -75,6 +75,9 @@
   :Darwin "STRIP=strip -x"
   :Linux "STRIP=strip --strip-unneeded -R .note -R .comment"})
 
+; convet a string into bool, based on the string value
+(defn str-to-bool [s] (if s (in (.lower s) ["true" "t" "yes" "y" "ok" "1" ""]) True))
+
 ; read in the config file if present
 (def config
   (let [

--- a/deken.hy
+++ b/deken.hy
@@ -76,7 +76,7 @@
   :Linux "STRIP=strip --strip-unneeded -R .note -R .comment"})
 
 ; convet a string into bool, based on the string value
-(defn str-to-bool [s] (if s (in (.lower s) ["true" "t" "yes" "y" "ok" "1" ""]) True))
+(defn str-to-bool [s] (and (not (nil? s)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
 
 ; read in the config file if present
 (def config

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ easywebdav==1.2.0
 pyelftools==0.23
 macholib==1.7
 python-gnupg==0.3.7
+keyring==4.0


### PR DESCRIPTION
(optionally) uses python-keyring to store the upload password in some secure place.
(optionally) uses gpg-agent to not have to enter the GPG-passphrase each time.
  https://github.com/pure-data/deken/issues/67

moved gpg-signing from "upload" into "package"