### PR TITLE
configfile for deken-plugin

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -174,7 +174,7 @@ proc ::deken::create_dialog {mytoplevel} {
 
     frame $mytoplevel.searchbit
     pack $mytoplevel.searchbit -side top -fill x
-    
+
     entry $mytoplevel.searchbit.entry -font 18 -relief sunken -highlightthickness 1 -highlightcolor blue
     pack $mytoplevel.searchbit.entry -side left -padx 6 -fill x -expand true
     bind $mytoplevel.searchbit.entry <Key-Return> "::deken::initiate_search $mytoplevel"
@@ -318,18 +318,39 @@ proc ::deken::download_progress {token total current} {
     }
 }
 
+# parse a deken-packagefilename into it's components: <pkgname>[-v<version>-]?{(<arch>)}-externals.zip
+# return: list <pkgname> <version> [list <arch> ...]
+proc ::deken::parse_filename {filename} {
+    set pkgname $filename
+    set archs [list]
+    if { [ regexp {(.*)-externals\..*} $filename match basename] } {
+	set pkgname $basename
+	# basename <pkgname>[-v<version>-]?{(<arch>)}
+	## strip off the archs
+	baselist = [split $basename () ]
+
+	# get pkgname + version
+	set pkgver [lindex $baselist 0]
+
+	# get archs
+	foreach {a _} [lreplace $baselist 0 0] { lappend archs $a }
+
+    }
+
+}
+
 # test for platform match with our current platform
 proc ::deken::architecture_match {title} {
     # if there are no architecture sections this must be arch-independent
     if {![regexp -- "\\\((.*?)-(.*?)-(.*?)\\\)" $title]} {
         return 1;
     }
-    
+
     # if the OS doesn't match, return false
     if {![regexp -- "$::deken::platform(os)" $title]} {
         return 0
     }
-    
+
     # if the word size doesn't match, return false
     if {![regexp -- "-$::deken::platform(bits)\\\)" $title]} {
         return 0
@@ -363,7 +384,7 @@ proc ::deken::search_for {term} {
 # create an entry for our search in the "help" menu
 set mymenu .menubar.help
 if {$::windowingsystem eq "aqua"} {
-    set inserthere 3    
+    set inserthere 3
 } else {
     set inserthere 4
 }

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -464,10 +464,13 @@ proc ::deken::search::puredata.info {term} {
             set decURL [urldecode $URL]
             set filename [ file tail $URL ]
             set cmd [list ::deken::clicked_link $decURL $filename]
+            set pkgverarch [ ::deken::parse_filename $filename ]
+
             set match [::deken::architecture_match $filename]
 
             set comment "Uploaded by $creator @ $date"
             set status $URL
+            set sortname [lindex $pkgverarch 0]--[lindex $pkgverarch 1]--$date
             set res [list $name $cmd $match $comment $status $filename]
             lappend searchresults $res
         }

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -207,8 +207,9 @@ proc ::deken::initiate_search {mytoplevel} {
     # make the ajax call
     if { [ catch {
         set results [::deken::search_for [$mytoplevel.searchbit.entry get]]
-    } ] } {
+    } stdout ] } {
         puts "online?"
+        puts "$stdout"
         ::deken::status "Unable to perform search. Are you online?"
     } else {
     # delete all text in the results

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -110,8 +110,12 @@ proc ::deken::readconfig {paths filename} {
 }
 
 
-set ::deken::installpath [ ::deken::get_writable_dir $::sys_staticpath ]
-#::pdwindow::post "installpath: $::deken::installpath\n"
+::deken::readconfig $::sys_staticpath deken-plugin.conf
+if { [ info exists ::deken::installpath ] } {
+    set ::deken::installpath [ ::deken::get_writable_dir [list $::deken::installpath ] ]
+} {
+    set ::deken::installpath [ ::deken::get_writable_dir $::sys_staticpath ]
+}
 
 # console message to let them know we're loaded
 ::pdwindow::post  "deken-plugin.tcl (Pd externals search) in $::current_plugin_loadpath loaded.\n"

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -323,20 +323,23 @@ proc ::deken::download_progress {token total current} {
 proc ::deken::parse_filename {filename} {
     set pkgname $filename
     set archs [list]
+    set version ""
     if { [ regexp {(.*)-externals\..*} $filename match basename] } {
-	set pkgname $basename
-	# basename <pkgname>[-v<version>-]?{(<arch>)}
-	## strip off the archs
-	baselist = [split $basename () ]
+        set pkgname $basename
+        # basename <pkgname>[-v<version>-]?{(<arch>)}
+        ## strip off the archs
+        set baselist [split $basename () ]
 
-	# get pkgname + version
-	set pkgver [lindex $baselist 0]
-
-	# get archs
-	foreach {a _} [lreplace $baselist 0 0] { lappend archs $a }
-
+        # get pkgname + version
+        set pkgver [lindex $baselist 0]
+        if { ! [ regexp "(.*)-(.*)-" $pkgver pkgname version ] } {
+            set pkgname $pkgver
+            set $version ""
+        }
+        # get archs
+        foreach {a _} [lreplace $baselist 0 0] { lappend archs $a }
     }
-
+    return [list $pkgname $version $archs]
 }
 
 # test for platform match with our current platform

--- a/plugin-config.md
+++ b/plugin-config.md
@@ -1,0 +1,43 @@
+the deken-plugin for Pd can be configured via a simple text-file.
+
+# deken-plugin.conf
+
+The configuration file for the deken-plugin
+is called `deken-plugin.conf`.
+
+Put it either directly near the `deken-plugin.tcl` file,
+or into a system-specific place (`$PdPath` resp `%PdPath` are the installation directory of your Pd):
+
+### Linux
+- `$PdPath/extra/deken-plugin/deken-plugin.conf`
+- `/usr/local/lib/pd-externals/deken-plugin/deken-plugin.conf`
+- `~/pd-externals/deken-plugin/deken-plugin.conf`
+
+### OSX
+- `$PdPath/extra/deken-plugin/deken-plugin.conf`
+- `/Library/Pd/deken-plugin/deken-plugin.conf`
+- `~/Library/Pd/deken-plugin/deken-plugin.conf`
+
+### W32
+- `%PdPath%\extra\deken-plugin\deken-plugin.conf`
+- `%AppData%\Pd\deken-plugin\deken-plugin.conf`
+- `%CommonProgramFiles%\Pd\deken-plugin\deken-plugin.conf`
+
+## Configuration Values
+
+Here are the possible values:
+
+ * `installpath` = Path where you would want to install the externals
+ (default: the first writeable path in the standard search paths)
+ (note: you should *always* use `/` as path-separator, even on W32!)
+
+
+All values are optional.
+
+## Example
+
+```
+installpath /tmp/dekentest
+## On W32 we would use something like
+#installpath D:/Pd/deken-test
+```


### PR DESCRIPTION
this patch-set adds a configuration-file for the deken-plugin

a full explanation is in  94879bdd and in `plugin-config.md`

the PR also contains some refactoring for parsing filenames into pkgname/version/archlist.