### PR TITLE
Require version when creating a package

### DIFF
--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -446,11 +446,15 @@
       (apply arg-package.add_argument ["source"] {"nargs" "+"
                                                   "metavar" "SOURCE"
                                                   "help" "The path to a directory of externals, abstractions, or GUI plugins to be packaged."})
-      (apply arg-package.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name." "default" "" "required" false})
+      (apply arg-package.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name."
+                                                                 "default" nil
+                                                                 "required" false})
       (apply arg-upload.add_argument ["source"] {"nargs" "+"
                                                  "metavar" "PACKAGE"
                                                  "help" "The path to an externals/abstractions/plugins zipfile to be uploaded, or a directory which will be packaged first automatically."})
-      (apply arg-upload.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name." "default" "" "required" false})
+      (apply arg-upload.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name. (in case a package is created)"
+                                                                "default" nil
+                                                                "required" false})
       (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the file into (defaults to /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" false})
       (apply arg-upload.add_argument ["--ask-password" "-P"] {"action" "store_true" "help" "Ask for upload password (rather than using password-manager." "default" "" "required" false})
       (apply arg-upload.add_argument ["--no-source-warning"] {"action" "store_true" "help" "Force-allow uploading of packages without sources." "required" false})

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -5,6 +5,7 @@
 (import os)
 (import re)
 (import argparse)
+(import datetime)
 
 (import platform)
 (import zipfile)
@@ -341,7 +342,15 @@
 
 ; compute the zipfile name for a particular external on this platform
 (defn make-archive-basename [folder version]
-  (+ (.rstrip folder "/\\") (if version (% "-v%s-" version) "") (get-architecture-strings folder) "-externals"))
+  (+ (.rstrip folder "/\\")
+     (cond [(nil? version) (sys.exit
+                            (+ (% "No version for '%s'!\n" folder)
+                               (% " If '%s' doesn't have a proper version number,\n" folder)
+                               (% " consider using a date-based fake version (like '0~%s')\n or an empty version ('')."
+                                  (.strftime (datetime.date.today) "%Y%m%d"))))]
+           [version (% "-v%s-" version)]
+           [True ""])
+     (get-architecture-strings folder) "-externals"))
 
 ; create additional files besides archive: hash-file and gpg-signature
 (defn archive-extra [zipfile]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -444,9 +444,11 @@
     [arg-upgrade (apply arg-subparsers.add_parser ["upgrade"])]]
       (apply arg-parser.add_argument ["--version"] {"action" "version" "version" version "help" "Outputs the version number of Deken."})
       (apply arg-package.add_argument ["source"] {"nargs" "+"
+                                                  "metavar" "SOURCE"
                                                   "help" "The path to a directory of externals, abstractions, or GUI plugins to be packaged."})
       (apply arg-package.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name." "default" "" "required" false})
       (apply arg-upload.add_argument ["source"] {"nargs" "+"
+                                                 "metavar" "PACKAGE"
                                                  "help" "The path to an externals/abstractions/plugins zipfile to be uploaded, or a directory which will be packaged first automatically."})
       (apply arg-upload.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name." "default" "" "required" false})
       (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the file into (defaults to /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" false})

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -410,7 +410,7 @@
     (list-comp
       (if (os.path.isdir name)
       ; if asking for a directory just package it up
-        (archive-extra (archive-dir name (make-archive-basename name args.version)))
+        (archive-extra (archive-dir name (make-archive-basename (.rstrip name "/\\") args.version)))
         (sys.exit (% "Not a directory '%s'!" name)))
       (name args.source)))
   ; upload packaged external to pure-data.info

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -345,6 +345,7 @@
   (+ (.rstrip folder "/\\")
      (cond [(nil? version) (sys.exit
                             (+ (% "No version for '%s'!\n" folder)
+                               " Please provide the version-number via the '--version' flag.\n"
                                (% " If '%s' doesn't have a proper version number,\n" folder)
                                (% " consider using a date-based fake version (like '0~%s')\n or an empty version ('')."
                                   (.strftime (datetime.date.today) "%Y%m%d"))))]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -443,10 +443,10 @@
     [arg-upload (apply arg-subparsers.add_parser ["upload"])]
     [arg-upgrade (apply arg-subparsers.add_parser ["upgrade"])]]
       (apply arg-parser.add_argument ["--version"] {"action" "version" "version" version "help" "Outputs the version number of Deken."})
-      (apply arg-package.add_argument ["source"] {"nargs" "*"
+      (apply arg-package.add_argument ["source"] {"nargs" "+"
                                                   "help" "The path to a directory of externals, abstractions, or GUI plugins to be packaged."})
       (apply arg-package.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name." "default" "" "required" false})
-      (apply arg-upload.add_argument ["source"] {"nargs" "*"
+      (apply arg-upload.add_argument ["source"] {"nargs" "+"
                                                  "help" "The path to an externals/abstractions/plugins zipfile to be uploaded, or a directory which will be packaged first automatically."})
       (apply arg-upload.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name." "default" "" "required" false})
       (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the file into (defaults to /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" false})


### PR DESCRIPTION
packages without versions are really a PITA (how is the user supposed to choose one of multiple files for the same library?).

so this patch makes a package-version mandatory when creating a new package.

if no version is specified, the error-message suggests a good one (based on the current date).

if you don't want to a version number, you can specify an empty one.

see #111 