### PR TITLE
make gpg optional (on the code level)

### DIFF
--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -198,7 +198,7 @@
 ;; handling GPG signatures
 (try (import gnupg)
   ;; read a value from the gpg config
-     (except [e ImportError] (defn gpg-sign-file [filename] (print (% "Unable to GPGP sign '%s':\n" filename) e)))
+     (except [e ImportError] (defn gpg-sign-file [filename] (print (% "Unable to GPG sign '%s'\n" filename) "'gnupg' module not loaded")))
      (else
       (defn gpg-get-config [gpg id]
         (let [[configdir (cond [gpg.gnupghome gpg.gnupghome] [True (os.path.join "~" ".gnupg")])]


### PR DESCRIPTION
this patch-set makes deken fail gracefully if there is no `gnupg` module installed.

deken still depends on `gnupg` so this code should hardly ever be triggered.

this PR features a more functional style of importing  gnupg and is based on the python3 branch (#120 )