### PR TITLE
settable install-dirs

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -52,7 +52,7 @@ proc ::deken::get_writable_dir {paths} {
     set fs [file separator]
     set access [list RDWR CREAT EXCL TRUNC]
     foreach p $paths {
-        if { [ catch { file mkdir $p } ] } {}
+        #if { [ catch { file mkdir $p } ] } {}
         for {set i 0} {True} {incr i} {
             set tmpfile "${p}${fs}dekentmp.${i}"
             if {![file exists $tmpfile]} {

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -173,6 +173,7 @@ proc ::deken::status {msg} {
 proc ::deken::post {msg {tag ""}} {
     variable mytoplevelref
     $mytoplevelref.results insert end "$msg\n" $tag
+    $mytoplevelref.results see end
 }
 proc ::deken::clearpost {} {
     variable mytoplevelref

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -333,8 +333,8 @@ proc ::deken::clicked_link {URL filename} {
     if { "$installdir" == "" } {
         ::deken::clearpost
         ::deken::post "No writeable directory found in:" warn
-        foreach p $::sys_staticpath { ::deken::post "\t- $p\n" warn }
-        ::deken::post "Cannot download/install libraries!\n" warn
+        foreach p $::sys_staticpath { ::deken::post "\t- $p" warn }
+        ::deken::post "Cannot download/install libraries!" warn
     } {
     set fullpkgfile "$installdir/$filename"
     ::deken::clearpost

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -327,7 +327,8 @@ proc ::deken::clicked_link {URL filename} {
         ::deken::post "No writeable directory found in:" warn
         foreach p $::sys_staticpath { ::deken::post "\t- $p" warn }
         ::deken::post "Cannot download/install libraries!" warn
-    } {
+        return
+    }
     set fullpkgfile "$installdir/$filename"
     ::deken::clearpost
     ::deken::post "Commencing downloading of:\n$URL\nInto $installdir..."
@@ -361,7 +362,6 @@ proc ::deken::clicked_link {URL filename} {
         pd_menucommands::menu_openfile $fullpkgfile
         ::deken::post "2. Copy the contents into $installdir.\n"
         pd_menucommands::menu_openfile $installdir
-    }
     }
 }
 

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -332,7 +332,7 @@ proc ::deken::clicked_link {URL filename} {
         set installdir [ ::deken::get_writable_dir [list [tk_chooseDirectory -title "Install to directory:" ] ] ]
     }
     if { "$installdir" == "" } {
-        ::deken::clearpost
+        #::deken::clearpost
         ::deken::post "No writeable directory found in:" warn
         foreach p $::sys_staticpath { ::deken::post "\t- $p" warn }
         ::deken::post "Cannot download/install libraries!" warn

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -191,6 +191,14 @@ proc ::deken::highlightable_posttag {tag} {
     # make sure that the 'highlight' tag is topmost
     $mytoplevelref.results tag raise highlight
 }
+proc ::deken::prompt_installdir {} {
+    set installdir [tk_chooseDirectory -title "Install libraries to directory:"]
+    if { "$installdir" != "" } {
+        set ::deken::installpath $installdir
+    }
+}
+
+
 proc ::deken::update_searchbutton {mytoplevel} {
     if { [$mytoplevel.searchbit.entry get] == "" } {
         $mytoplevel.searchbit.button configure -text [_ "Show all" ]
@@ -250,6 +258,8 @@ proc ::deken::create_dialog {mytoplevel} {
     pack $mytoplevel.status -side bottom -fill x
     label $mytoplevel.status.label -textvariable ::deken::statustext
     pack $mytoplevel.status.label -side left -padx 6
+    button $mytoplevel.status.button -text [_ "Set install dir"] -default active -width 9 -command "::deken::prompt_installdir"
+    pack $mytoplevel.status.button -side right -padx 6 -pady 3
 
     text $mytoplevel.results -takefocus 0 -cursor hand2 -height 100 -yscrollcommand "$mytoplevel.results.ys set"
     scrollbar $mytoplevel.results.ys -orient vertical -command "$mytoplevel.results yview"

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -121,19 +121,6 @@ proc ::deken::readconfig {paths filename} {
 
 
 ::deken::readconfig $::sys_staticpath deken-plugin.conf
-if { [ info exists ::deken::installpath ] } {
-    set ::deken::installpath [ ::deken::get_writable_dir [list $::deken::installpath ] ]
-} {
-    set ::deken::installpath [ ::deken::get_writable_dir $::sys_staticpath ]
-}
-
-# console message to let them know we're loaded
-::pdwindow::post  "deken-plugin.tcl (Pd externals search) in $::current_plugin_loadpath loaded.\n"
-if { "$::deken::installpath" == "" } {
-    ::pdwindow::error "deken: No writeable directory found in:\n"
-    foreach p $::sys_staticpath { ::pdwindow::error "\t- $p\n" }
-    ::pdwindow::error "deken: Will not be able to download/install libraries\n"
-}
 
 set ::deken::platform(os) $::tcl_platform(os)
 set ::deken::platform(machine) $::tcl_platform(machine)
@@ -152,7 +139,12 @@ if { "Windows" eq "$::deken::platform(os)" } {
     #if { "amd64" eq "$::deken::platform(machine)" } { set ::deken::platform(machine) "x86_64" }
 }
 
-::pdwindow::post "Platform detected: $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(bits)bit\n"
+# console message to let them know we're loaded
+## but only if we are being called as a plugin (not as built-in)
+if { "" != "$::current_plugin_loadpath" } {
+    ::pdwindow::post "deken-plugin.tcl (Pd externals search) in $::current_plugin_loadpath loaded.\n"
+    ::pdwindow::post "Platform detected: $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(bits)bit\n"
+}
 
 # architectures that can be substituted for eachother
 array set ::deken::architecture_substitutes {}

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -238,6 +238,8 @@ proc ::deken::create_dialog {mytoplevel} {
     bind $mytoplevel.searchbit.entry <Key-Return> "::deken::initiate_search $mytoplevel"
     bind $mytoplevel.searchbit.entry <KeyRelease> "::deken::update_searchbutton $mytoplevel"
     focus $mytoplevel.searchbit.entry
+    button $mytoplevel.searchbit.button -text [_ "Show all"] -default active -width 9 -command "::deken::initiate_search $mytoplevel"
+    pack $mytoplevel.searchbit.button -side right -padx 6 -pady 3
 
     frame $mytoplevel.warning
     pack $mytoplevel.warning -side top -fill x
@@ -248,9 +250,6 @@ proc ::deken::create_dialog {mytoplevel} {
     pack $mytoplevel.status -side bottom -fill x
     label $mytoplevel.status.label -textvariable ::deken::statustext
     pack $mytoplevel.status.label -side left -padx 6
-
-    button $mytoplevel.searchbit.button -text [_ "Show all"] -default active -width 9 -command "::deken::initiate_search $mytoplevel"
-    pack $mytoplevel.searchbit.button -side right -padx 6 -pady 3
 
     text $mytoplevel.results -takefocus 0 -cursor hand2 -height 100 -yscrollcommand "$mytoplevel.results.ys set"
     scrollbar $mytoplevel.results.ys -orient vertical -command "$mytoplevel.results yview"

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -4,7 +4,7 @@
 # ex: set setl sw=2 sts=2 et
 
 # Search URL:
-# http://puredata.info/search_rss?SearchableText=xtrnl-
+# http://deken.puredata.info/search?name=foobar
 
 # The minimum version of TCL that allows the plugin to run
 package require Tcl 8.4

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -18,6 +18,16 @@ package require http 2
 package require pdwindow 0.1
 package require pd_menucommands 0.1
 
+## only register this plugin if there isn't any newer version already registered
+## (if ::deken::version is defined and is higher than our own version)
+
+if { [info exists ::deken::version ] && [string compare $::deken::version 0.1] >= 0} {
+    ::pdwindow::debug "\[deken\]: the installed version appears to be up-to-date or newer...skipping!\n"
+} {
+namespace eval ::deken:: {
+    variable version 0.1
+}
+
 namespace eval ::deken:: {
     namespace export open_searchui
     variable mytoplevelref
@@ -28,7 +38,6 @@ namespace eval ::deken:: {
     variable statustimer
     variable backends
     namespace export register
-    variable version 0.1
 }
 namespace eval ::deken::search:: { }
 
@@ -527,3 +536,4 @@ proc ::deken::search::puredata.info {term} {
 }
 
 ::deken::register ::deken::search::puredata.info
+}

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -324,13 +324,17 @@ proc ::deken::clicked_link {URL filename} {
     ### if this still doesn't help, ask the user
     set installdir ""
     if { [ info exists ::deken::installpath ] } {
+        ## any previous choice?
         set installdir [ ::deken::get_writable_dir [list $::deken::installpath ] ]
     }
     if { "$installdir" == "" } {
+        ## search the default paths
         set installdir [ ::deken::get_writable_dir $::sys_staticpath ]
     }
     if { "$installdir" == "" } {
-        set installdir [ ::deken::get_writable_dir [list [tk_chooseDirectory -title "Install to directory:" ] ] ]
+        ## ask the user (and remember the decision)
+        ::deken::prompt_installdir
+        set installdir [ ::deken::get_writable_dir [list $::deken::installpath ] ]
     }
     if { "$installdir" == "" } {
         #::deken::clearpost


### PR DESCRIPTION
this branch has a couple of minor improvements in the light of the plugin included into Pd-vanilla.

namely it allows to set the installation dir manually (there's a new button for setting the dir).
also, the plugin no longer tries to 'mkdir' any standard path (it seems that @millerpuckette disliked this).

the patch-set also includes some minor amendments for inclusion into Pd-vanilla (e.g. only show boiler-plate messages when run as plugin - not as built-in)