### PR TITLE
[WIP] Info page launch

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -330,7 +330,7 @@ proc ::deken::open_searchui {mytoplevel} {
 proc ::deken::create_dialog {mytoplevel} {
     toplevel $mytoplevel -class DialogWindow
     variable mytoplevelref $mytoplevel
-    wm title $mytoplevel [_ "Find externals"]
+    wm title $mytoplevel [_ "Find externals & info"]
     wm geometry $mytoplevel 670x550
     wm minsize $mytoplevel 230 360
     wm transient $mytoplevel
@@ -529,7 +529,7 @@ proc ::deken::openBrowser {url pMenu} {
     if [catch {::deken::launchBrowser $url} err] {
         tk_messageBox -icon error -message "error '$err' with '$command'"
     }
-	unset $pMenu
+	destroy .popupMenu
 }
 
 # download a file to a location

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -274,7 +274,6 @@ proc ::deken::bind_postmenu {tag cmd} {
     variable mytoplevelref
     set rcmd [regsub -- "clicked_link" $cmd "rclicked_link"] 
     set cmd2 "$rcmd .menu %x %y"
-#    puts " bind_postmenu $tag : $cmd / $cmd2"
     $mytoplevelref.results tag bind $tag <3> $cmd2
 }
 
@@ -500,36 +499,31 @@ proc ::deken::clicked_link {URL filename} {
 }
 
 proc ::deken::rclicked_link {url packageFilename theMenu theX theY} {
-	puts ""
-	puts "rclicked_link $url $packageFilename $theMenu $theX $theY "
 	set lastSlash [string last / $url]
 	set urlPath [string range $url 0 $lastSlash]
 	
     set beforeFirstOpenBrace [expr [string first ( $packageFilename] - 1]
     set filenameBase [string range $packageFilename 0 $beforeFirstOpenBrace]
     
-#	puts "$urlPath $theMenu $theX $theY"
-	
 	set indexUrl "${urlPath}moreInfo"
 	set objectListUrl "${urlPath}${filenameBase}objects.txt"
-	puts "indexUrl: $indexUrl"
-	puts "objectListUrl: $objectListUrl" 
 	
+	if { [winfo exists .popupMenu] } {
+		destroy .popupMenu
+	}
     set pMenu [menu .popupMenu]
 
     variable mytoplevelref
-	$pMenu add command -label "List Objects" -command "::deken::openBrowser $objectListUrl $pMenu"
-	$pMenu add command -label "More Info"    -command "::deken::openBrowser $indexUrl $pMenu"
+	$pMenu add command -label "List Objects" -command "::deken::open_browser $objectListUrl"
+	$pMenu add command -label "More Info"    -command "::deken::open_browser $indexUrl"
+	$pMenu add command -label "Download"     -command "::deken::download_file $url $packageFilename"
 	tk_popup $pMenu [expr [winfo rootx $mytoplevelref.results] + $theX] [expr [winfo rooty $mytoplevelref.results] + $theY]
-    variable pMenuRef $pMenu
 }
 
-proc ::deken::openBrowser {url pMenu} {
-	puts "openBrowser: $url $pMenu"
-    if [catch {::deken::launchBrowser $url} err] {
+proc ::deken::open_browser {url} {
+    if [catch {::deken::launch_browser $url} err] {
         tk_messageBox -icon error -message "error '$err' with '$command'"
     }
-	destroy .popupMenu
 }
 
 # download a file to a location
@@ -711,7 +705,7 @@ proc ::deken::search::puredata.info {term} {
 }
 
 #http://wiki.tcl.tk/557
-proc ::deken::launchBrowser url {
+proc ::deken::launch_browser url {
     global tcl_platform
 
     if {$tcl_platform(platform) eq "windows"} {
@@ -730,12 +724,6 @@ proc ::deken::launchBrowser url {
         set command [list xdg-open]
     }
     exec {*}$command $url &
-}
-
-proc ::deken::_launchBrowser {url} {
-    if [catch {::deken::launchBrowser $url} err] {
-        tk_messageBox -icon error -message "error '$err' with '$command'"
-    }
 }
 
 ::deken::register ::deken::search::puredata.info

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -274,7 +274,11 @@ proc ::deken::bind_postmenu {tag cmd} {
     variable mytoplevelref
     set rcmd [regsub -- "clicked_link" $cmd "rclicked_link"] 
     set cmd2 "$rcmd .menu %x %y"
-    $mytoplevelref.results tag bind $tag <3> $cmd2
+    if {"$::deken::platform(os)" eq "Darwin"} {
+        $mytoplevelref.results tag bind $tag <2> $cmd2
+    } else {
+        $mytoplevelref.results tag bind $tag <3> $cmd2
+    }
 }
 
 proc ::deken::highlightable_posttag {tag} {
@@ -522,7 +526,7 @@ proc ::deken::rclicked_link {url packageFilename theMenu theX theY} {
 
 proc ::deken::open_browser {url} {
     if [catch {::deken::launch_browser $url} err] {
-        tk_messageBox -icon error -message "error '$err' with '$command'"
+        tk_messageBox -icon error -message "error '$err' with 'launch_browser $url'"
     }
 }
 
@@ -706,16 +710,14 @@ proc ::deken::search::puredata.info {term} {
 
 #http://wiki.tcl.tk/557
 proc ::deken::launch_browser url {
-    global tcl_platform
-
-    if {$tcl_platform(platform) eq "windows"} {
+    if {"$::deken::platform(os)" eq "Windows"} {
         # first argument to "start" is "window title", which is not used here
         set command [list {*}[auto_execok start] {}]
         if {[file isdirectory $url]} {
             # if there is an executable named eg ${url}.exe, avoid opening that instead:
             set url [file nativename [file join $url .]]
         }
-    } elseif {$tcl_platform(os) eq "Darwin"} {
+    } elseif {"$::deken::platform(os)" eq "Darwin"} {
         # It *is* generally a mistake to use $tcl_platform(os) to select functionality,
         # particularly in comparison to $tcl_platform(platform).  For now, let's just
         # regard it as a stylistic variation subject to debate.


### PR DESCRIPTION
Very much work in progress. It complains on the Mac with an 'extra characters after close-brace' error. The same file works ok on Linux. Didn't dare on Windows yet. The right-click function bind is a bit of a hack.
P.S. It works on Windows 10 :-).
P.P.S.S. The MacOSX issue appears to be Tcl/Tk version related, the syntax isn't supported by the current version of Tcl, which is 8.5 on my 10.11.6 Mac. 