### PR TITLE
hy12 support

### DIFF
--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -82,8 +82,9 @@
 (def hasher hashlib.sha256)
 (def hash-extension (.pop (hasher.__name__.split "_")))
 
-;; nil? has gone from hy-0.12
-(defn nil? [x] (= x None))
+;; nil? has been removed from hy-0.12
+(try (nil? None) (except [e NameError] (defn nil? [x] (= x None))))
+
 ;; in hy-0.12 'slice' has been replaced with 'cut'
 ;; but we cannot replace 'cut' in hy>=0.12, because it is a built-in...
 (defn cut-slice [x y z] (cut x y z))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -21,8 +21,6 @@
 (import [getpass [getpass]])
 (try (import [urlparse [urlparse]])
  (except [e ImportError] (import [urllib.parse [urlparse]])))
-(import requests)
-(import easywebdav)
 
 (require hy.contrib.loop)
 
@@ -356,6 +354,7 @@
 ;; upload a zipped up package to puredata.info
 (defn upload-file [filepath destination username password]
   ;; get username and password from the environment, config, or user input
+  (import easywebdav)
   (if filepath
     (do
      (setv filename (os.path.basename filepath))
@@ -436,6 +435,7 @@
 
 ;; check if the given package has a sources-arch on puredata.info
 (defn check-sources@puredata-info [pkg username]
+  (import requests)
   (print (% "Checking puredata.info for Source package for '%s'" pkg))
   (in pkg
       ;; list of package/version matching 'pkg' that have 'Source' archictecture

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -302,23 +302,23 @@
      (.close tarf)
      tar-file)))
 
-; do we use zip or tar on this archive?
+;; do we use zip or tar on this archive?
 (defn archive-extension [rootname]
   (if (or (in "(Windows" rootname) (not (in "(" rootname))) ".zip" ".tar.gz"))
 
-; automatically pick the correct archiver - windows or "no arch" = zip
+;; automatically pick the correct archiver - windows or "no arch" = zip
 (defn archive-dir [directory-to-archive rootname]
   (let [[ext (archive-extension rootname)]]
     ((if (= ext ".zip") zip-dir tar-dir) directory-to-archive rootname)))
 
-; naive check, whether we have an archive: compare against known suffixes
+;; naive check, whether we have an archive: compare against known suffixes
 (defn is-archive? [filename]
   (len (list-comp f [f [".zip" ".tar.gz" ".tgz"]] (.endswith (filename.lower) f))))
 
-; upload a zipped up package to puredata.info
+;; upload a zipped up package to puredata.info
 (defn upload-file [filepath destination username password]
+  ;; get username and password from the environment, config, or user input
   (if filepath
-   (let [
     ;; get username and password from the environment, config, or user input
     [filename (os.path.basename filepath)]
     [[pkg ver arch ext] (parse-filename filename)]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -84,6 +84,10 @@
 
 ;; nil? has gone from hy-0.12
 (defn nil? [x] (= x None))
+;; in hy-0.12 'slice' has been replaced with 'cut'
+;; but we cannot replace 'cut' in hy>=0.12, because it is a built-in...
+(defn cut-slice [x y z] (cut x y z))
+(try (cut []) (except [e NameError] (defn cut-slice [x y z] (slice x y z))))
 
 ;; convert a string into bool, based on the string value
 (defn str-to-bool [s] (and (not (nil? s)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
@@ -166,7 +170,7 @@
     [[oshint
       (+ (elf-arch-types.get (elf.header.get "e_machine") None)
          (or (parse-arm-elf-arch elf) ""))
-      (int (get (.get (elf.header.get "e_ident") "EI_CLASS") (slice -2 None)))]])
+      (int (cut-slice (.get (elf.header.get "e_ident") "EI_CLASS") -2 None))]])
    (except [e exceptions.ELFError] [])))
 
 ;; get architecture from a Darwin Mach-O file (OSX)
@@ -187,7 +191,7 @@
   ;; the arm cpu can be found in the 'aeabi' section
   (setv data (and arm-section (.startswith (arm-section.data) A) (.index (arm-section.data) "aeabi") (.pop (.split (arm-section.data) "aeabi"))))
   (if data
-    (get arm-cpu-arch (ord (get (get (.split (get data (slice 7 None)) "\x00" 1) 1) 1)))))
+    (get arm-cpu-arch (ord (get (get (.split (cut-slice data 7 None) "\x00" 1) 1) 1)))))
 
 ;; try to obtain a value from environment, then config file, then prompt user
 (defn get-config-value [name &rest default]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -74,7 +74,7 @@
 (defn dict-merge [d1 d2] (apply dict [d1] (or d2 {})))
 
 ;; apply attributes to objects in a functional way
-(defn set-attr [obj attr value] (do (setattr obj attr value) obj))
+(defn set-attr [obj attr value] (setattr obj attr value) obj)
 ;; get multiple attributes as list
 (defn get-attrs [obj attributes &optional default] (list-comp (getattr obj _default) [_ attributes]))
 
@@ -375,11 +375,10 @@
 
 ;; create additional files besides archive: hash-file and gpg-signature
 (defn archive-extra [zipfile]
-  (do
    (print "Packaging" zipfile)
    (hash-sum-file zipfile)
    (gpg-sign-file zipfile)
-   zipfile))
+   zipfile)
 
 ;; parses a filename into a (pkgname version archs extension) tuple
 ;; missing values are None
@@ -400,16 +399,16 @@
 
 ;; check if the given package has a sources-arch on puredata.info
 (defn check-sources@puredata-info [pkg username]
-  (do (print (% "Checking puredata.info for Source package for '%s'" pkg))
-      (in pkg
-          ;; list of package/version matching 'pkg' that have 'Source' archictecture
-          (list-comp
-           (has-sources? p)
-           [p
-            (list-comp
-             (try-get (.split (try-get (.split x "\t") 1) "/") -1)  ; filename part of the download URL
-             [x (.splitlines (getattr (requests.get (% "http://deken.puredata.info/search?name=%s" (get (.split pkg "/") 0))) "text"))]
-             (= username (try-get (.split x "\t") 2)))]))))
+  (print (% "Checking puredata.info for Source package for '%s'" pkg))
+  (in pkg
+      ;; list of package/version matching 'pkg' that have 'Source' archictecture
+      (list-comp
+       (has-sources? p)
+       [p
+        (list-comp
+         (try-get (.split (try-get (.split x "\t") 1) "/") -1)  ; filename part of the download URL
+         [x (.splitlines (getattr (requests.get (% "http://deken.puredata.info/search?name=%s" (get (.split pkg "/") 0))) "text"))]
+         (= username (try-get (.split x "\t") 2)))])))
 
 ;; check if sources archs are present by comparing a SET of packagaes and a SET of packages-with-sources
 (defn check-sources [pkgs sources &optional puredata-info-user]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -287,7 +287,9 @@
           (if (not sig)
             (print "WARNING: Could not GPG sign the package.")
             (do
-             (with [f (open signfile "w")] (.write f (str sig)))
+             (setv f (open signfile "w"))
+             (.write f (str sig))
+             (.close f)
              signfile)))
          (except [e OSError] (print (.join "\n"
                                            ["WARNING: GPG signing failed:"
@@ -318,18 +320,20 @@
        (except [e RuntimeError] (zipfile.ZipFile filename "w"))))
 (defn zip-dir [directory-to-zip archive-file]
   (setv zip-filename (+ archive-file ".zip"))
-  (with [f (zip-file zip-filename)]
-        (for [[root dirs files] (os.walk directory-to-zip)]
-          (for [file files]
-            (setv file-path (os.path.join root file))
-              (f.write file-path (os.path.relpath file-path (os.path.join directory-to-zip ".."))))))
+  (setv f (zip-file zip-filename))
+  (for [[root dirs files] (os.walk directory-to-zip)]
+    (for [file files]
+      (setv file-path (os.path.join root file))
+      (f.write file-path (os.path.relpath file-path (os.path.join directory-to-zip "..")))))
+  (.close f)
   zip-filename)
 
 ;; tar up the directory
 (defn tar-dir [directory-to-tar archive-file]
   (setv tar-file (+ archive-file ".tar.gz"))
-  (with [f (tarfile.open tar-file "w:gz")]
-        (.add f directory-to-tar))
+  (setv f (tarfile.open tar-file "w:gz"))
+  (.add f directory-to-tar)
+  (.close f)
   tar-file)
 
 ;; do we use zip or tar on this archive?

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -327,31 +327,31 @@
 (defn upload-file [filepath destination username password]
   ;; get username and password from the environment, config, or user input
   (if filepath
-    (setv filename (os.path.basename filepath))
-    (setv [pkg ver _ _] (parse-filename filename))
-    (setv url (urlparse destination))
-    (setv proto (or url.scheme "https"))
-    (setv host (or url.netloc externals-host))
-    (setv [proto host path] (get-attrs (urlparse destination)))
-    (setv path
-          (str
-           (replace-words
-            (or (.rstrip url.path "/") "/Members/%u/software/%p/%v")
-            (, (, "%u" username) (, "%p" pkg) (, "%v" (or ver ""))))))
-    (setv url (+ proto "://" host path))
-    (setv dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto}))
-    (print (+ "Uploading " filename " to " url))
-    (try
-     (do
-      ;; make sure all directories exist
-      (dav.mkdirs path)
-      ;; upload the package file
-      (dav.upload filepath (+ path "/" filename)))
-     (except [e easywebdav.client.OperationFailed]
-       (sys.exit (+
-                  (% "Couldn't upload to %s!\n" url)
-                  (% "Are you sure you have the correct username and password set for '%s'?\n" host)
-                  (% "Please ensure the folder '%s' exists on the server and is writeable." path)))))))
+    (do
+     (setv filename (os.path.basename filepath))
+     (setv [pkg ver _ _] (parse-filename filename))
+     (setv url (urlparse destination))
+     (setv proto (or url.scheme "https"))
+     (setv host (or url.netloc externals-host))
+     (setv path
+           (str
+            (replace-words
+             (or (.rstrip url.path "/") "/Members/%u/software/%p/%v")
+             (, (, "%u" username) (, "%p" pkg) (, "%v" (or ver ""))))))
+     (setv url (+ proto "://" host path))
+     (setv dav (apply easywebdav.connect [host] {"username" username "password" password "protocol" proto}))
+     (print (+ "Uploading " filename " to " url))
+     (try
+      (do
+       ;; make sure all directories exist
+       (dav.mkdirs path)
+       ;; upload the package file
+       (dav.upload filepath (+ path "/" filename)))
+      (except [e easywebdav.client.OperationFailed]
+        (sys.exit (+
+                   (% "Couldn't upload to %s!\n" url)
+                   (% "Are you sure you have the correct username and password set for '%s'?\n" host)
+                   (% "Please ensure the folder '%s' exists on the server and is writeable." path))))))))
 
 ;; upload a list of archives (given the archive-filename it will also upload some extra-files (sha256, gpg,...))
 (defn upload-package [pkg destination username password]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -50,7 +50,28 @@
   "EM_BLAFKIN" "Analog Devices Blackfin"
   "RESERVED" "RESERVED"})
 
-(def arm-cpu-arch ["Pre-v4" "v4" "v4T" "v5T" "v5TE" "v5TEJ" "v6" "v6KZ" "v6T2" "v6K" "v7"])
+;; values updated via https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob;f=include/elf/arm.h;hb=HEAD#l93
+(def arm-cpu-arch
+  [
+   "Pre-v4"
+   "v4"
+   "v4T"
+   "v5T"
+   "v5TE"
+   "v5TEJ"
+   "v6"
+   "v6KZ"
+   "v6T2"
+   "v6K"
+   "v7"
+   "v6_M"
+   "v6S_M"
+   "v7E_M"
+   "v8"
+   "v8R"
+   "v8M_BASE"
+   "v8M_MAIN"
+   ])
 
 (def win-types {
   "0x014c" ["i386" 32]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1,5 +1,5 @@
 #!/usr/bin/env hy
-; deken upload --version 0.1 ./freeverb~/
+;; deken upload --version 0.1 ./freeverb~/
 
 (import sys)
 (import os)
@@ -57,29 +57,29 @@
   "0x0200" ["x86_64" 64]
   "0x8664" ["amd64" 64]})
 
-; algorithm to use to hash files
+;; algorithm to use to hash files
 (def hasher hashlib.sha256)
 (def hash-extension (.pop (hasher.__name__.split "_")))
 
-; convert a string into bool, based on the string value
+;; convert a string into bool, based on the string value
 (defn str-to-bool [s] (and (not (nil? s)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
 
 ;; join non-empty elements
 (defn join-nonempty [joiner elements] (.join joiner (list-comp (str x) [x elements] x)))
 
-; concatenate two dictionaries - hylang's assoc is broken
+;; concatenate two dictionaries - hylang's assoc is broken
 (defn dict-merge [d1 d2] (apply dict [d1] (or d2 {})))
 
-; apply attributes to objects in a functional way
+;; apply attributes to objects in a functional way
 (defn set-attr [obj attr value] (do (setattr obj attr value) obj))
 
-; replace multiple words (given as pairs in <repls>) in a string <s>
+;; replace multiple words (given as pairs in <repls>) in a string <s>
 (defn replace-words [s repls] (reduce (fn [a kv] (apply a.replace kv)) repls s))
 
 ;; get a value at an index or a default
 (defn try-get [elements index &optional default] (try (get elements index) (except [e IndexError] default)))
+;; read in the config file if present
 
-; read in the config file if present
 (def config
   (let [
     [config-file (SafeConfigParser)]
@@ -87,7 +87,7 @@
       (config-file.readfp file-buffer)
       (dict (config-file.items "default"))))
 
-; takes the externals architectures and turns them into a string
+;; takes the externals architectures and turns them into a string
 (defn get-architecture-strings [folder]
   (let [[archs (get-externals-architectures folder)]
         [sep-1 ")("]
@@ -96,11 +96,11 @@
       (+ "(" (sep-1.join (set (list-comp (sep-2.join (list-comp (str a) [a arch])) [arch archs]))) ")")
       "")))
 
-; check if a particular file has an extension in a set
+;; check if a particular file has an extension in a set
 (defn test-extensions [filename extensions]
   (len (list-comp e [e extensions] (filename.endswith e))))
 
-; examine a folder for externals and return the architectures of those found
+;; examine a folder for externals and return the architectures of those found
 (defn get-externals-architectures [folder]
   (sum (list-comp (cond
       [(test-extensions f [".pd_linux" ".l_ia64" ".l_i386" ".l_arm" ".so"]) (get-elf-arch (os.path.join folder f) "Linux")]
@@ -141,7 +141,7 @@
      [[oshint (+ (elf-arch-types.get (elf.header.get "e_machine") nil) (or (parse-arm-elf-arch elf) "")) (int (slice (.get (elf.header.get "e_ident") "EI_CLASS") -2))]])
    (except [e exceptions.ELFError] [])))
 
-; get architecture from a Darwin Mach-O file (OSX)
+;; get architecture from a Darwin Mach-O file (OSX)
 (defn get-mach-arch [filename]
   (import [macholib.MachO [MachO]])
   (import [macholib.mach_o [MH_MAGIC_64 CPU_TYPE_NAMES]])
@@ -150,7 +150,7 @@
       (list-comp ["Darwin" (CPU_TYPE_NAMES.get h.header.cputype h.header.cputype) (if (= h.MH_MAGIC MH_MAGIC_64) 64 32)] [h macho.headers]))
    (except [e ValueError] [])))
 
-; gets the specific flavour of arm by hacking the .ARM.attributes ELF section
+;; gets the specific flavour of arm by hacking the .ARM.attributes ELF section
 (defn parse-arm-elf-arch [arm-elf]
   (let [[arm-section (if arm-elf (try (arm-elf.get_section_by_name ".ARM.attributes")))]
         [data (and arm-section (.startswith (arm-section.data) "A") (.index (arm-section.data) "aeabi") (.pop (.split (arm-section.data) "aeabi")))]]
@@ -195,7 +195,7 @@
 
 ;; handling GPG signatures
 (try (import gnupg)
-  ;; read a value from the gpg config
+     ;; read a value from the gpg config
      (except [e ImportError] (defn gpg-sign-file [filename] (print (% "Unable to GPG sign '%s'\n" filename) "'gnupg' module not loaded")))
      (else
       (defn gpg-get-config [gpg id]
@@ -347,7 +347,7 @@
                                              username)))
       (for [pkg pkgs] (upload-package pkg destination username password))))
 
-; compute the zipfile name for a particular external on this platform
+;; compute the zipfile name for a particular external on this platform
 (defn make-archive-basename [folder version]
   (+ (.rstrip folder "/\\")
      (cond [(nil? version) (sys.exit
@@ -360,7 +360,7 @@
            [True ""])
      (get-architecture-strings folder) "-externals"))
 
-; create additional files besides archive: hash-file and gpg-signature
+;; create additional files besides archive: hash-file and gpg-signature
 (defn archive-extra [zipfile]
   (do
    (print "Packaging" zipfile)
@@ -368,13 +368,13 @@
    (gpg-sign-file zipfile)
    zipfile))
 
-; parses a filename into a (pkgname version archs extension) tuple
-; missing values are nil
+;; parses a filename into a (pkgname version archs extension) tuple
+;; missing values are None
 (defn parse-filename [filename]
   (list-comp (get
-                ; parse filename with a regex
+                ;; parse filename with a regex
                 (re.split r"(.*/)?(.+?)(-v(.+)-)?((\([^\)]+\))+|-)*-externals\.([a-z.]*)" filename) x)
-                ; extract only the fields of interested
+                ;; extract only the fields of interested
              [x [2 4 5 7]]))
 (defn filename-to-namever [filename]
   (let [[[pkg ver arch ext] (parse-filename filename)]] (join-nonempty "/" [pkg ver])))
@@ -394,7 +394,7 @@
            (has-sources? p)
            [p
             (list-comp
-             (try-get (.split (try-get (.split x "\t") 1) "/") -1) ;; filename part of the download URL
+             (try-get (.split (try-get (.split x "\t") 1) "/") -1)  ; filename part of the download URL
              [x (.splitlines (getattr (requests.get (% "http://deken.puredata.info/search?name=%s" (get (.split pkg "/") 0))) "text"))]
              (= username (try-get (.split x "\t") 2)))]))))
 
@@ -453,7 +453,7 @@
   :upgrade (fn [args]
     (sys.exit "The upgrade script isn't here, it's in the Bash wrapper!"))})
 
-; kick things off by using argparse to check out the arguments supplied by the user
+;; kick things off by using argparse to check out the arguments supplied by the user
 (defn main []
   (let [
     [arg-parser (apply argparse.ArgumentParser [] {"prog" "deken" "description" "Deken is a build tool for Pure Data externals."})]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -32,7 +32,7 @@
 (def externals-host "puredata.info")
 
 (def elf-arch-types {
-  "EM_NONE" nil
+  "EM_NONE" None
   "EM_386" "i386"
   "EM_68K" "m68k"
   "EM_IA_64" "x86_64"
@@ -60,6 +60,9 @@
 ;; algorithm to use to hash files
 (def hasher hashlib.sha256)
 (def hash-extension (.pop (hasher.__name__.split "_")))
+
+;; nil? has gone from hy-0.12
+(defn nil? [x] (= x None))
 
 ;; convert a string into bool, based on the string value
 (defn str-to-bool [s] (and (not (nil? s)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
@@ -118,7 +121,7 @@
       [(test-extensions f [".pd_darwin" ".d_fat" ".d_ppc"]) (get-mach-arch (os.path.join folder f))]
       [(test-extensions f [".m_i386" ".dll"]) (get-windows-arch (os.path.join folder f))]
       [(test-extensions f [".c" ".cpp" ".C" ".cxx" ".cc"]) [["Sources"]]]
-      [true []])
+      [True []])
     [f (os.listdir folder)]) []))
 
 ; get architecture strings from a windows DLL

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -72,12 +72,22 @@
 
 ;; apply attributes to objects in a functional way
 (defn set-attr [obj attr value] (do (setattr obj attr value) obj))
+;; get multiple attributes as list
+(defn get-attrs [obj attributes &optional default] (list-comp (getattr obj _default) [_ attributes]))
 
 ;; replace multiple words (given as pairs in <repls>) in a string <s>
 (defn replace-words [s repls] (reduce (fn [a kv] (apply a.replace kv)) repls s))
 
-;; get a value at an index or a default
-(defn try-get [elements index &optional default] (try (get elements index) (except [e IndexError] default)))
+;; get multiple values from a dict (give keys as list, get values as list)
+(defn get-values [coll keys] (list-comp (get coll _) [_ keys]))
+
+;; get a value at an index/key or a default
+(defn try-get [elements index &optional default]
+  (try (get elements index)
+       (except [e TypeError] default)
+       (except [e KeyError] default)
+       (except [e IndexError] default)))
+
 ;; read in the config file if present
 
 (def config

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -61,14 +61,6 @@
 (def hasher hashlib.sha256)
 (def hash-extension (.pop (hasher.__name__.split "_")))
 
-; get the externals' homedir install location for this platform - from s_path.c
-(def externals-folder
-  (let [[system-name (platform.system)]]
-    (cond
-      [(in system-name ["Linux" "FreeBSD"]) (os.path.expandvars (os.path.join "$HOME" "pd-externals"))]
-      [(= system-name "Darwin") (os.path.expandvars (os.path.join "$HOME" "Library" "Pd"))]
-      [(= system-name "Windows") (os.path.expandvars (os.path.join "%AppData%" "Pd"))])))
-
 ; convert a string into bool, based on the string value
 (defn str-to-bool [s] (and (not (nil? s)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
 


### PR DESCRIPTION
This branch fixes `hy-0.12` support (Closes https://github.com/pure-data/deken/issues/150)

The only thing that is currently not working is the `arm-elf-arch` parser under *Python3* (it's working fine under *Python2*).

It still works under `hy-0.11` (both with *Python2* and *Python3*).
I haven't tested any older version of `hy`.

I haven't checked whether it would work with `hy-0.13`

