### PR TITLE
set installpath variable at load & naming consistency

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -434,7 +434,7 @@ proc ::deken::clicked_link {URL filename} {
     ### if ::deken::installpath is set, use the first writable item
     ### if not, get a writable item from one of the searchpaths
     ### if this still doesn't help, ask the user
-    set installdir ::deken::find_installpath
+    set installdir [::deken::find_installpath]
     if { "$installdir" == "" } {
         ## ask the user (and remember the decision)
         ::deken::prompt_installdir

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -268,7 +268,7 @@ proc ::deken::highlightable_posttag {tag} {
     $mytoplevelref.results tag raise highlight
 }
 proc ::deken::prompt_installdir {} {
-    set installdir [tk_chooseDirectory -title [_ "Install libraries to directory:"] ]
+    set installdir [tk_chooseDirectory -title [_ "Install externals to directory:"] ]
     if { "$installdir" != "" } {
         ::deken::set_installpath $installdir
         return 1


### PR DESCRIPTION
This is a tiny backport from https://github.com/pure-data/pure-data/pull/140

The default naming for things handled by deken within the GUI seems to be "externals". This PR changes one entry form "libraries" to match that. Whether "externals" is a good term is probably best argued elsewhere ;)