### PR TITLE
verbose log platform print when loaded internally

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -237,6 +237,9 @@ if { "" != "$::current_plugin_loadpath" } {
     ::pdwindow::post "\n"
     ::pdwindow::post [format [_ "\[deken\] Platform detected: %s" ] $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(bits)bit ]
     ::pdwindow::post "\n"
+} else {
+    ::pdwindow::verbose 0 [format [_ "\[deken\] Platform detected: %s" ] $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(bits)bit ]
+    ::pdwindow::verbose 0 "\n"
 }
 
 # architectures that can be substituted for eachother

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -156,7 +156,7 @@ Set objShell = Nothing
 set ::deken::_vbsunzip ""
 
 proc ::deken::get_tmpfilename {{path ""}} {
-    for {set i 0} {True} {incr i} {
+    for {set i 0} {true} {incr i} {
         set tmpfile [file join ${path} dekentmp.${i}]
         if {![file exists $tmpfile]} {
             return $tmpfile


### PR DESCRIPTION
This small PR adds a verbose log print for the detected deken platform. This should be help when debugging issues with deken included in Pd.