### PR TITLE
backporting downstream 0.48.0 release work

### DIFF
--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -475,7 +475,7 @@ proc ::deken::clicked_link {URL filename} {
                         # if docsdir is set & the install path is valid,
                         # saying "no" is temporary to ensure the docsdir
                         # hierarchy remains, use the Path dialog to override
-                        if {[namespace exists ::pd_docsdir] && [::pd_docsdir::path_is_valid] && \
+                        if {[namespace exists ::pd_docsdir] && [::pd_docsdir::path_is_valid] &&
                             [file writable [file normalize $prevpath]] } {
                             set keepprevpath 0
                         }
@@ -545,7 +545,8 @@ proc ::deken::clicked_link {URL filename} {
         pd_menucommands::menu_openfile $installdir
     }
 
-    # add to the search paths?
+    # add to the search paths? bail if the version of pd doesn't support it
+    if {[uplevel 1 info procs add_to_searchpaths] eq ""} {return}
     set extpath [file join $installdir $extname]
     if {![file exists $extpath]} {
         ::deken::post [_ "Unable to add %s to search paths"] $extname
@@ -557,8 +558,8 @@ proc ::deken::clicked_link {URL filename} {
         yes {
             add_to_searchpaths [file join $installdir $extname]
             ::deken::post [format [_ "Added %s to search paths"] $extname]
-            # if this version of pd support its, try refreshing the helpbrowser
-            if {[info proc ::helpbrowser::refresh] ne ""} {
+            # if this version of pd supports it, try refreshing the helpbrowser
+            if {[uplevel 1 info procs ::helpbrowser::refresh] ne ""} {
                 ::helpbrowser::refresh
             }
         }


### PR DESCRIPTION
There is a probably a better way to do this, but here goes. A manual backport on work I've done on deken downstream with the Pd sources.

* allow ignoring prefs setting when finding installpath
* open choose dir dialog in $::fileopendir
* dialogs now open as children of the main deken window
* pd_docsdir support:
  * try using docspath/externals when installing
  * if installpath is docspath/externals, choosing a new dir is only temporary
* optionally add downloaded externals path to search paths
* add menu separator before Find Externals... entry

 I've tried to make sure new dependencies such as pd_docsdir are checked for existence before being used, so this shouldn't blow up if used with older Pd versions.