### PR TITLE
[WIP] fix architecture matching and fileformat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ matrix:
       env: PIP=pip
 
 before_install:
-  - export DEKEN_BASE_URL=https://raw.githubusercontent.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}developer
+  - export DEKEN_BASE_URL=https://raw.githubusercontent.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}/developer
+  - echo ${DEKEN_BASE_URL}
 
 install:
   - mkdir -p ~/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       env: PIP=pip
 
 before_install:
-  - export DEKEN_BASE_URL=https://raw.githubusercontent.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/developer
+  - export DEKEN_BASE_URL=https://raw.githubusercontent.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}developer
 
 install:
   - mkdir -p ~/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - python: "3.6"
       env: PIP=pip
 
+before_install:
+  - export DEKEN_BASE_URL=https://raw.githubusercontent.com/${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG}/developer
+
 install:
   - mkdir -p ~/bin
   - mkdir -p tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
 # if not, we just pip 'requiremements.txt' directly
   - if [[ "x${TRAVIS_PR_BRANCH:-${TRAVIS_BRANCH}}" != "xmaster" ]]; then "${PIP}" install -r developer/requirements.txt; else ~/bin/deken upgrade ; fi
   - ./developer/deken package -v000.dekenci tmp/deken-test
+  - ./developer/deken package --dekformat 0 -v000.dekenci tmp/deken-test
 
 after_script:
   - ls -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.6"
-
 matrix:
   include:
     - language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       env: PIP=pip
 
 before_install:
-  - export DEKEN_BASE_URL=https://raw.githubusercontent.com/${TRAVIS_PULL_REQUEST_SLUG:-TRAVIS_REPO_SLUG}/developer
+  - export DEKEN_BASE_URL=https://raw.githubusercontent.com/${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}/developer
 
 install:
   - mkdir -p ~/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ matrix:
   include:
     - language: generic
       os: osx
+      env: PIP=pip2
+    - python: "2.7"
+      env: PIP=pip
+    - python: "3.6"
+      env: PIP=pip
 
 install:
   - mkdir -p ~/bin
@@ -21,7 +26,7 @@ script:
 # 'deken upgrade' downloads files from the 'master' branch, so we can only use
 # it, if this CI-build is actually run for this 'master' branch.
 # if not, we just pip 'requiremements.txt' directly
-  - if [[ "x${TRAVIS_PR_BRANCH:-${TRAVIS_BRANCH}}" != "xmaster" ]]; then pip install -r developer/requirements.txt; else ~/bin/deken upgrade ; fi
+  - if [[ "x${TRAVIS_PR_BRANCH:-${TRAVIS_BRANCH}}" != "xmaster" ]]; then "${PIP}" install -r developer/requirements.txt; else ~/bin/deken upgrade ; fi
   - ./developer/deken package -v000.dekenci tmp/deken-test
 
 after_script:

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -396,6 +396,7 @@ if {[info command lreverse] == ""} {
 set ::deken::platform(os) $::tcl_platform(os)
 set ::deken::platform(machine) $::tcl_platform(machine)
 set ::deken::platform(bits) [ expr [ string length [ format %X -1 ] ] * 4 ]
+set ::deken::platform(floatsize) 32
 
 # normalize W32 OSs
 if { [ string match "Windows *" "$::deken::platform(os)" ] > 0 } {
@@ -434,13 +435,16 @@ set ::deken::architecture_substitutes(ppc) [list "PowerPC"]
 set ::deken::installpath [::deken::find_installpath]
 
 # allow overriding deken platform from Pd-core
-proc ::deken::set_platform {os machine bits floatwidth} {
+proc ::deken::set_platform {os machine bits floatsize} {
     if { $os != $::deken::platform(os) ||
          $machine != $::deken::platform(machine) ||
-         $bits != $::deken::platform(bits)} {
+         $bits != $::deken::platform(bits) ||
+         $floatsize != $::deken::platform(floatsize)
+     } {
         set ::deken::platform(os) ${os}
         set ::deken::platform(machine) ${machine}
         set ::deken::platform(bits) ${bits}
+        set ::deken::platform(floatsize) ${floatsize}
 
         ::pdwindow::verbose 1 [format [_ "\[deken\] Platform re-detected: %s" ] ${os}-${machine}-${bits}bit ]
         ::pdwindow::verbose 1 "\n"
@@ -1126,6 +1130,7 @@ proc ::deken::architecture_match {archs} {
     set OS "$::deken::platform(os)"
     set MACHINE "$::deken::platform(machine)"
     set BITS "$::deken::platform(bits)"
+    set FLOATSIZE "$::deken::platform(floatsize)"
     if { "$::deken::userplatform" != "" } {
         ## FIXXME what if the user-supplied input isn't valid?
         regexp -- {(.*)-(.*)-(.*)} $::deken::userplatform _ OS MACHINE BITS

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1049,9 +1049,9 @@ proc ::deken::download_file {URL outputfilename} {
     set ncode [::http::ncode $httpresult]
     if {[expr $ncode != 200 ]} {
         ## FIXXME: we probably should handle redirects correctly (following them...)
-        # tcl-format
-        set err [::http::code $token]
-        ::pdwindow::error [format [_ "Unable to download from %1\$s \[%2\$s\]" ] $URL $err ] error
+        set err [::http::code $httpresult]
+        ::pdwindow::error [format [_ "Unable to download from %1\$s \[%2\$s\]" ] $URL $err ]
+        ::pdwindow::error "\n"
         set outputfilename ""
     }
     flush $f

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1114,9 +1114,14 @@ proc ::deken::parse_filename {filename} {
     set archs [list]
     set version ""
     if { [ string match "*.dek" $filename ] } {
-        ## deken filename v1: <library>[<version>](<arch1>)(<arch2>).dek
+        ## deken filename v1: <library>[v<version>](<arch1>)(<arch2>).dek
         set archstring ""
-        regexp {^([^\[\]\(\)]+)(\[[^\[\]\(\)]+\])?((\([^\[\]\(\)]+\))*)\.dek$} $filename _ pkgname version archstring
+        regexp {^([^\[\]\(\)]+)((\[[^\[\]\(\)]+\])*)((\([^\[\]\(\)]+\))*)\.dek$} $filename _ pkgname optionstring _ archstring
+        foreach {o _} [lreplace [split $optionstring {[]}] 0 0] {
+            if {![string first v ${o}]} {
+                set version [string range $o 1 end]
+            } { # ignoring unknown option... }
+        }
         foreach {a _} [lreplace [split $archstring "()"] 0 0] { lappend archs $a }
     } elseif { [ regexp {(.*)-externals\..*} $filename _ basename] } {
         ## deken filename v0

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1158,7 +1158,7 @@ proc ::deken::architecture_match {archs} {
     set FLOATSIZE "$::deken::platform(floatsize)"
     if { "$::deken::userplatform" != "" } {
         ## FIXXME what if the user-supplied input isn't valid?
-        regexp -- {(.*)-(.*)-(.*)} $::deken::userplatform _ OS MACHINE BITS
+        regexp -- {(.*)-(.*)-(.*)} $::deken::userplatform _ OS MACHINE FLOATSIZE
     }
 
     # check each architecture in our list against the current one

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1131,7 +1131,12 @@ proc ::deken::parse_filename {filename} {
             set $version ""
         }
         # get archs
-        foreach {a _} [lreplace $baselist 0 0] { lappend archs $a }
+        foreach {a _} [lreplace $baselist 0 0] {
+            # in filename.v0 the semantics of the last arch field ("bits") was unclear
+            # since this format predates float64 builds, we just force it to 32
+            regsub -- {-[0-9]+$} $a {-32} a
+            lappend archs $a
+        }
         if { "x$archs$version" == "x" } {
             # try again as <pkgname>-v<version>
             if { ! [ regexp "(.*)-(v.*)" $pkgver _ pkgname version ] } {

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -377,8 +377,12 @@ proc ::deken::find_installpath {{ignoreprefs false}} {
     return $installpath
 }
 
-proc ::deken::platform2string {} {
-    return $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(bits)
+proc ::deken::platform2string {{verbose 0}} {
+    if { $verbose } {
+        return $::deken::platform(os)-$::deken::platform(machine)-float$::deken::platform(floatsize)
+    } {
+        return $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(floatsize)
+    }
 }
 
 # list-reverter (compat for tcl<8.5)

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1163,9 +1163,9 @@ proc ::deken::architecture_match {archs} {
 
     # check each architecture in our list against the current one
     foreach arch $archs {
-        if { [ regexp -- {(.*)-(.*)-(.*)} $arch _ os machine bits ] } {
-            if { "${os}" eq "$::deken::platform(os)" } {
-                ## so OS matches...
+        if { [ regexp -- {(.*)-(.*)-(.*)} $arch _ os machine floatsize ] } {
+            if { "${os}" eq "${OS}" && "${floatsize}" eq "${FLOATSIZE}" } {
+                ## so OS and floatsize match...
                 ## check whether the CPU matches as well
                 if { "${machine}" eq "${MACHINE}" } {return 1}
                 ## not exactly; see whether it is in the list of compat CPUs

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1056,6 +1056,7 @@ proc ::deken::clicked_link {URL filename} {
 # download a file to a location
 # http://wiki.tcl.tk/15303
 proc ::deken::download_file {URL outputfilename} {
+    set URL [string map {{[} "%5b" {]} "%5d"} $URL]
     set downloadfilename [::deken::get_tmpfilename [file dirname $outputfilename] ]
     set f [open $downloadfilename w]
     fconfigure $f -translation binary

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1104,7 +1104,9 @@ proc ::deken::download_progress {token total current} {
     }
 }
 
-# parse a deken-packagefilename into it's components: <pkgname>[-v<version>-]?{(<arch>)}-externals.zip
+# parse a deken-packagefilename into it's components:
+# v0:: <pkgname>[-v<version>-]?{(<arch>)}-externals.<ext>
+# v1:: <pkgname>[\[<version\]]?{(<arch>)}
 # return: list <pkgname> <version> [list <arch> ...]
 proc ::deken::parse_filename {filename} {
     set pkgname $filename

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -421,7 +421,7 @@ if { "" != "$::current_plugin_loadpath" } {
     ::pdwindow::debug [format [_ "\[deken\] deken-plugin.tcl (Pd externals search) loaded from %s." ]  $::current_plugin_loadpath ]
     ::pdwindow::debug "\n"
 }
-::pdwindow::verbose 0 [format [_ "\[deken\] Platform detected: %s" ] [::deken::platform2string] ]
+::pdwindow::verbose 0 [format [_ "\[deken\] Platform detected: %s" ] [::deken::platform2string 1] ]
 ::pdwindow::verbose 0 "\n"
 
 # architectures that can be substituted for eachother
@@ -450,7 +450,7 @@ proc ::deken::set_platform {os machine bits floatsize} {
         set ::deken::platform(bits) ${bits}
         set ::deken::platform(floatsize) ${floatsize}
 
-        ::pdwindow::verbose 1 [format [_ "\[deken\] Platform re-detected: %s" ] ${os}-${machine}-${bits}bit ]
+        ::pdwindow::verbose 1 [format [_ "\[deken\] Platform re-detected: %s" ] [::deken::platform2string 1] ]
         ::pdwindow::verbose 1 "\n"
     }
 }

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1112,7 +1112,14 @@ proc ::deken::parse_filename {filename} {
     set pkgname $filename
     set archs [list]
     set version ""
-    if { [ regexp {(.*)-externals\..*} $filename _ basename] } {
+    if { [ string match "*.dek" $filename ] } {
+        set archstring ""
+        if { ! [ regexp "(.*)\\\[(.*)\\\](\(.*\))\.dek" $filename _ pkgname version archstring] } {
+            regexp "(.*)(\(.*\))\.dek" $filename _ pkgname archstring
+        }
+        foreach {a _} [lreplace [split $archstring "()"] 0 0] { lappend archs $a }
+    } elseif { [ regexp {(.*)-externals\..*} $filename _ basename] } {
+        ## deken filename v0
         set pkgname $basename
         # basename <pkgname>[-v<version>-]?{(<arch>)}
         ## strip off the archs

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1233,13 +1233,17 @@ proc ::deken::search::puredata.info {term} {
 
     # deken-specific socket config
     set httpaccept [::http::config -accept]
+    set httpagent [::http::config -useragent]
+    set pdversion "Pd/$::PD_MAJOR_VERSION.$::PD_MINOR_VERSION.$::PD_BUGFIX_VERSION$::PD_TEST_VERSION"
     ::http::config -accept text/tab-separated-values
+    ::http::config -useragent "Deken/${::deken::version} ([::deken::platform2string]) ${pdversion} Tcl/[info patchlevel]"
 
     # fetch search result
     set token [::http::geturl "${dekenserver}?${queryterm}"]
 
     # restore http settings
     ::http::config -accept $httpaccept
+    ::http::config -useragent $httpagent
 
     set ncode [::http::ncode $token]
     if {[expr $ncode != 200 ]} {

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -1113,10 +1113,9 @@ proc ::deken::parse_filename {filename} {
     set archs [list]
     set version ""
     if { [ string match "*.dek" $filename ] } {
+        ## deken filename v1: <library>[<version>](<arch1>)(<arch2>).dek
         set archstring ""
-        if { ! [ regexp "(.*)\\\[(.*)\\\](\(.*\))\.dek" $filename _ pkgname version archstring] } {
-            regexp "(.*)(\(.*\))\.dek" $filename _ pkgname archstring
-        }
+        regexp {^([^\[\]\(\)]+)(\[[^\[\]\(\)]+\])?((\([^\[\]\(\)]+\))*)\.dek$} $filename _ pkgname version archstring
         foreach {a _} [lreplace [split $archstring "()"] 0 0] { lappend archs $a }
     } elseif { [ regexp {(.*)-externals\..*} $filename _ basename] } {
         ## deken filename v0

--- a/deken-plugin.tcl
+++ b/deken-plugin.tcl
@@ -220,7 +220,14 @@ proc ::deken::utilities::extract {installdir filename fullpkgfile} {
     set PWD [ pwd ]
     cd $installdir
     set success 1
-    if { [ string match *.zip $fullpkgfile ] } then {
+    if { [ string match *.dek $fullpkgfile ] } then {
+        if { [ ::deken::utilities::unzipper $fullpkgfile  $installdir ] } { } {
+            if { [ catch { exec unzip -uo $fullpkgfile } stdout ] } {
+                ::pdwindow::debug "$stdout\n"
+                set success 0
+            }
+        }
+    } elseif { [ string match *.zip $fullpkgfile ] } then {
         if { [ ::deken::utilities::unzipper $fullpkgfile  $installdir ] } { } {
             if { [ catch { exec unzip -uo $fullpkgfile } stdout ] } {
                 ::pdwindow::debug "$stdout\n"

--- a/developer/README.md
+++ b/developer/README.md
@@ -25,8 +25,8 @@ See [config.md](./config.md) for deken's configuration file format.
 You have a directory containing your compiled externals object files called
 `my_external`.
 
-This command will create a file like `my_external-v0.1-(Linux-amd64-64)-externals.zip`
-and upload it to your account on <http://puredata.info/> where the search plugin
+This command will create a file like `my_external[v0.1](Linux-amd64-64).dek`
+and upload it to your account on <https://puredata.info/> where the search plugin
 can find it:
 
 	$ deken package -v 0.1 my_external
@@ -38,7 +38,7 @@ command for you in one step:
 	$ deken upload -v 0.1 my_external
 
 The upload step will also generate a .sha256 checksum file and upload it along
-with the zip file.
+with the dek file.
 
 
 ### Creating/Uploading packages on a different machine
@@ -51,7 +51,7 @@ Example: You build the "my_external" library on OSX-10.5, but (due to OSX-10.5
 not being supported by Apple anymore) you haven't installed `deken` there.
 So you simply transfer the "my_external" directory to your Linux machine, where
 you run `deken package my_external` and it will magically create the
-`my_external-v3.14-(Darwin-i386-32)(Darwin-x86_64-32)-externals.tgz` file for
+`my_external[v3.14](Darwin-i386-32)(Darwin-amd64-32)-externals.tgz` file for
 you, ready to be uploaded.
 
 ## Filename format ##
@@ -59,7 +59,7 @@ you, ready to be uploaded.
 The `deken` tool names a zipfile of externals binaries with a specific format to
 be optimally searchable on [puredata.info](http://puredata.info/);
 
-	LIBNAME[-vVERSION-]{(ARCH)}-externals.EXT
+	LIBNAME[vVERSION]{(ARCH)}.dek
 
  * LIBNAME is the name of the externals package ("zexy", "cyclone", "freeverb~").
  * VERSION contains the version information for the end use
@@ -71,49 +71,49 @@ be optimally searchable on [puredata.info](http://puredata.info/);
    with:
    - OS being the Operating System (`Linux`, `Darwin`, `W32`,...)
    - MARCH is the machine architecture (e.g. `x86_64`)
-   - BIT is some number of bits (e.g. `32`)
- * EXT is the archive extension (either `zip` or `tar.gz`)
+   - BIT is the size of Pd's numbers in bits (usually `32`; for double-precision it is `64`)
 
 Note that the archive should contain a single directory at the top level with
 NAME the same as the externals package itself. For example a freeverb~ externals
 package would contain a directory "freeverb~" at the top level of the zipfile in
 which the externals live.
 
-The square brackets around the "-vVERSION-" section are to indicate it is
-optional, don't include them. The same goes for the curly braces around the
-"(ARCH)" (indicating that this section can be repeated multiple times).
-However, the round parentheses "()" around architectures must be included to
+The version string must be enclosed by square brackets (`[]`) and start with a `v`.
+The version string itself must not contain any brackets or parentheses.
+Strictly speaking, the version (with the enclosing brackets) is optional, however
+it is highly suggested that you provide it.
+
+The curly braces around the "(ARCH)" specifiers are only to indicate that this section
+can occur multiple times (or not at all).
+However, the round parentheses "()" enclosing the architectures string must be included to
 separate the architectures visibly from each other.
 
 In plain English this means:
-> the library-name, followed by an optional version string (starting with `-v`
-> and ending with `-`), followed by zero or more architecture specifications
-> (each surrounded by `(`parentheses`)`), and terminated by `-externals`
-> (followed by a filename extension).
+> the library-name, followed by an optional version string (starting with `[v`
+> and ending with `]`), followed by zero or more architecture specifications
+> (each surrounded by `(`parentheses`)`), and terminated by `.dek`.
 
 
 Here is the actual regular expression used:
 
-    (.*/)?(.+?)(-v(.+)-)?((\([^\)]+\))+|-)*-externals\.([a-z.]*)
+    (.*/)?([^\[\]\(\)]+)(\[v[^\[\]\(\)]+\])?((\([^\[\]\(\)]+\))*)\.(dek)
 
 with the following matching groups:
 
  - ~~`#0` anything before the path (always empty and *ignored*)~~
  - ~~`#1` = path to filename (*ignored*)~~
  -   `#2` = library name
- - ~~`#3` = version string with decoration (*ignored*)~~
- -   `#4` = version
- -   `#5` = archs
- - ~~`#6` = last arch in archs (*ignored*)~~
- -   `#7` = extension
- - ~~`#8` anything after the extension (should be empty and is *ignored*)~~
+ - ~~`#3` = options (including the version)
+ -   `#4` = archs
+ - ~~`#5` = last arch in archs (*ignored*)~~
+ -   `#6` = extension ('dek')
 
 Some examples:
 
-    adaptive-v0.0.extended-(Linux-i386-32)(Linux-amd64-64)-externals.tar.gz
-    adaptive-v0.0.extended-(Sources)-externals.tar.gz
-    freeverb~(Darwin-i386-32)(Darwin-x86_64-32)(Sources)-externals.zip
-    list-abs-v0.1--externals.zip
+    adaptive[v0.0.extended](Linux-i386-32)(Linux-amd64-32).dek
+    adaptive[v0.0.extended](Sources).dek
+    freeverb~(Darwin-i386-32)(Darwin-x86_64-32)(Sources).dek
+    list-abs[v0.1].dek
 
 
 ## Sourceful uploads
@@ -146,8 +146,8 @@ For uploading a Source package along with binary packages, you can upload one
 package file with multiple archs (including a "Sources" arch) or multiple package
 files (one for the "Sources" arch).
 
-    deken upload frobnozzel(Windows-i386-32)(Sources)-externals.zip
-    deken upload foobar-v0.1-(Linux-x86_64-64)-externals.tgz foobar-v0.1-(Sources)-externals.tgz
+    deken upload frobnozzel(Windows-i386-32)(Sources).dek
+    deken upload foobar[v0.1](Linux-x86_64-32).dek foobar[v0.1](Sources).dek
 
 ## Upgrade ##
 

--- a/developer/README.md
+++ b/developer/README.md
@@ -157,20 +157,3 @@ files (one for the "Sources" arch).
 ## Show help ##
 
 	$ deken -h
-
-## Platform ##
-
-OSX Example
-
-	$ deken --platform
-	Darwin-i386-64bit
-
-Linux example
-
-	$ deken --platform
-	Linux-x86_64-64bit-ELF
-
-Raspbian
-
-	$ deken --platform
-	Linux-armv6l-32bit-ELF

--- a/developer/deken
+++ b/developer/deken
@@ -9,7 +9,9 @@
 export DEKEN_VERSION="0.2.6"
 export DEKEN_HOME="${DEKEN_HOME:-"$HOME/.deken"}"
 DEKEN_GIT_BRANCH="${DEKEN_GIT_BRANCH:-master}"
-DEKEN_BASE_URL="https://raw.githubusercontent.com/pure-data/deken/${DEKEN_GIT_BRANCH}/developer"
+if [ "x${DEKEN_BASE_URL}" = "x" ]; then
+    DEKEN_BASE_URL="https://raw.githubusercontent.com/pure-data/deken/${DEKEN_GIT_BRANCH}/developer"
+fi
 
 VIRTUALENV_VERSION="15.1.0"
 VIRTUALENV_URL="https://pypi.io/packages/source/v/virtualenv/virtualenv-${VIRTUALENV_VERSION}.tar.gz"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -754,13 +754,13 @@
          {"nargs" "+"
                   "metavar" "SOURCE"
                   "help" "The path to a directory of externals, abstractions, or GUI plugins to be packaged."})
-  (apply arg-package.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name."
+  (apply arg-package.add_argument ["--version" "-v"] {"help" "A library version number to insert into the package name."
                                                              "default" None
                                                              "required" False})
   (apply arg-upload.add_argument ["source"] {"nargs" "+"
                                                      "metavar" "PACKAGE"
                                                      "help" "The path to an externals/abstractions/plugins zipfile to be uploaded, or a directory which will be packaged first automatically."})
-  (apply arg-upload.add_argument ["--version" "-v"] {"help" "An external version number to insert into the package name. (in case a package is created)"
+  (apply arg-upload.add_argument ["--version" "-v"] {"help" "A library version number to insert into the package name, in case a package is created."
                                                             "default" None
                                                             "required" False})
   (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the file into (defaults to /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" False})

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -186,10 +186,10 @@
     (if (test-extensions-under-dir folder [".c" ".cpp" ".C" ".cxx" ".cc"])
         [[["Sources"]]] [])
     (list-comp (cond
-      [(test-extensions f [".pd_linux" ".l_ia64" ".l_i386" ".l_arm" ".so"]) (get-elf-arch (os.path.join folder f) "Linux")]
-      [(test-extensions f [".pd_freebsd" ".b_i386"]) (get-elf-arch (os.path.join folder f) "FreeBSD")]
-      [(test-extensions f [".pd_darwin" ".d_fat" ".d_ppc"]) (get-mach-arch (os.path.join folder f))]
-      [(test-extensions f [".m_i386" ".dll"]) (get-windows-arch (os.path.join folder f))]
+      [(test-extensions f [".pd_linux" ".l_ia64" ".l_i386" ".l_arm" ".so"]) (get-elf-archs (os.path.join folder f) "Linux")]
+      [(test-extensions f [".pd_freebsd" ".b_i386"]) (get-elf-archs (os.path.join folder f) "FreeBSD")]
+      [(test-extensions f [".pd_darwin" ".d_fat" ".d_ppc"]) (get-mach-archs (os.path.join folder f))]
+      [(test-extensions f [".m_i386" ".dll"]) (get-windows-archs (os.path.join folder f))]
       [True []])
     [f (os.listdir folder)]
     (os.path.exists (os.path.join folder f))))) []))
@@ -203,7 +203,7 @@
 
 
 ;; Linux ELF file
-(defn get-elf-arch [filename &optional [oshint "Linux"]]
+(defn get-elf-archs [filename &optional [oshint "Linux"]]
   (def elf-osabi {
                   "ELFOSABI_SYSV" None
                   "ELFOSABI_HPUX" "HPUX"
@@ -316,7 +316,7 @@
 
 
 ;; macOS MachO file
-(defn get-mach-arch [filename]
+(defn get-mach-archs [filename]
   (def macho-cpu {
                   1 "vac"
                   6 "m68k"
@@ -355,7 +355,7 @@
        (except [e Exception] (list))))
 
 ;; Windows PE file
-(defn get-windows-arch [filename]
+(defn get-windows-archs [filename]
   (defn get-pe-sectionarchs [cpu symbols]
     (list-comp (, "Windows" cpu (classnew-to-floatsize fun)) [fun symbols]))
   (defn get-pe-archs [pef cpudict]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -529,7 +529,7 @@
 
 ;; tar up the directory
 (defn tar-dir [directory-to-tar archive-file &optional [extension ".tar.gz"]]
-  (setv tar-file (+ archive-file ".tar.gz"))
+  (setv tar-file (+ archive-file extension))
   (defn tarfilter [tarinfo]
     (setv tarinfo.name (os.path.relpath tarinfo.name (os.path.join directory-to-tar "..")))
     tarinfo)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -163,8 +163,7 @@
 ;; takes the externals architectures and turns them into a string
 (defn get-architecture-strings [folder]
   (defn _get_archs [archs]
-    (print archs)
-     (if archs
+    (if archs
        (+
         "("
         (.join ")(" (list-comp a [a (sorted (set archs))] (!= a "Sources")))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -113,6 +113,9 @@
 (def hasher hashlib.sha256)
 (def hash-extension (.pop (hasher.__name__.split "_")))
 
+;; simple debugging helper: prints an object and returns it
+(defn debug [x] (print "DEBUG: " x) x)
+
 ;; nil? has been removed from hy-0.12
 (try (nil? None) (except [e NameError] (defn nil? [x] (= x None))))
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -658,7 +658,8 @@
   (or (if (not force-ask)
           (or (try (do
                       (import keyring)
-                      (keyring.get_password "deken" username)))
+                      (keyring.get_password "deken" username))
+                   (except [e Exception] (print "WARNING: " e)))
               (get-config-value "password")))
       (getpass (% "Please enter password for uploading as '%s': " username))))
 
@@ -692,7 +693,8 @@
              (if password
                (try (do
                      (import keyring)
-                     (keyring.set_password "deken" username password)))))
+                     (keyring.set_password "deken" username password))
+                    (except [e Exception] (print "WARNING: " e)))))
   ;; the rest should have been caught by the wrapper script
   :upgrade (fn [args] (sys.exit "'upgrade' not implemented for this platform!"))
   :update  (fn [args] (sys.exit "'upgrade' not implemented for this platform!"))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -626,18 +626,6 @@
    (get-architecture-strings folder)
    filenameversion))
 
-;; compute the zipfile name for a particular external on this platform
-(defn make-archive-basename [folder version]
-  (+ (os.path.basename folder)
-     (cond [(nil? version) (sys.exit
-                            (+ (% "No version for '%s'!\n" folder)
-                               " Please provide the version-number via the '--version' flag.\n"
-                               (% " If '%s' doesn't have a proper version number,\n" folder)
-                               (% " consider using a date-based fake version (like '0~%s')\n or an empty version ('')."
-                                  (.strftime (datetime.date.today) "%Y%m%d"))))]
-           [version (% "-v%s-" version)]
-           [True ""])
-     (get-architecture-strings folder) "-externals"))
 
 ;; create additional files besides archive: hash-file and gpg-signature
 (defn archive-extra [zipfile]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -548,7 +548,7 @@
 
 ;; naive check, whether we have an archive: compare against known suffixes
 (defn is-archive? [filename]
-  (len (list-comp f [f [".zip" ".tar.gz" ".tgz"]] (.endswith (filename.lower) f))))
+  (len (list-comp f [f [".dek" ".zip" ".tar.gz" ".tgz"]] (.endswith (filename.lower) f))))
 
 ;; upload a zipped up package to puredata.info
 (defn upload-file [filepath destination username password]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -759,11 +759,11 @@
                                                              "required" False})
   (apply arg-upload.add_argument ["source"] {"nargs" "+"
                                                      "metavar" "PACKAGE"
-                                                     "help" "The path to an externals/abstractions/plugins zipfile to be uploaded, or a directory which will be packaged first automatically."})
+                                                     "help" "The path to a package file to be uploaded, or a directory which will be packaged first automatically."})
   (apply arg-upload.add_argument ["--version" "-v"] {"help" "A library version number to insert into the package name, in case a package is created."
                                                             "default" None
                                                             "required" False})
-  (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the file into (defaults to /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" False})
+  (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the package to (DEFAULT: /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" False})
   (apply arg-upload.add_argument ["--ask-password" "-P"] {"action" "store_true" "help" "Ask for upload password (rather than using password-manager." "default" "" "required" False})
   (apply arg-upload.add_argument ["--no-source-error"] {"action" "store_true" "help" "Force-allow uploading of packages without sources." "required" False})
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -757,6 +757,9 @@
   (apply arg-package.add_argument ["--version" "-v"] {"help" "A library version number to insert into the package name."
                                                              "default" None
                                                              "required" False})
+  (apply arg-package.add_argument ["--dekformat"] {"help" "Override the deken packaging format (DEFAULT: 1)."
+                                                   "default" 1
+                                                   "required" False})
   (apply arg-upload.add_argument ["source"] {"nargs" "+"
                                                      "metavar" "PACKAGE"
                                                      "help" "The path to a package file to be uploaded, or a directory which will be packaged first automatically."})
@@ -766,6 +769,9 @@
   (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the package to (DEFAULT: /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" False})
   (apply arg-upload.add_argument ["--ask-password" "-P"] {"action" "store_true" "help" "Ask for upload password (rather than using password-manager." "default" "" "required" False})
   (apply arg-upload.add_argument ["--no-source-error"] {"action" "store_true" "help" "Force-allow uploading of packages without sources." "required" False})
+  (apply arg-upload.add_argument ["--dekformat"] {"help" "Override the deken packaging format, in case a package is created. (DEFAULT: 1)."
+                                                  "default" 1
+                                                  "required" False})
 
   (setv arguments (.parse_args arg-parser))
   (setv command (.get commands (keyword arguments.command)))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -558,13 +558,13 @@
   (for [pkg pkgs] (upload-package pkg destination username password)))
 
 ;; compute the archive filename for a particular external on this platform
-;; v1: "<pkgname>[<version>](<arch1>)(<arch2>).dek"
+;; v1: "<pkgname>[v<version>](<arch1>)(<arch2>).dek"
 ;; v0: "<pkgname>-v<version>-(<arch1>)(<arch2>)-externals.tar.gz" (resp. ".zip")
 (defn make-archive-name [folder version &optional [filenameversion 1]]
   (defn do-make-name [pkgname version archs filenameversion]
     (cond
      [(= filenameversion 1) (+ pkgname
-                               (if version (% "[%s]" version) "")
+                               (if version (% "[v%s]" version) "")
                                archs
                                ".dek")]
      [(= filenameversion 0) (+ pkgname
@@ -606,7 +606,7 @@
 (defn parse-filename1 [filename]
   (try
    (get-values
-    (re.split r"(.*/)?([^\[\]\(\)]+)(\[[^\[\]\(\)]+\])?((\([^\[\]\(\)]+\))*)\.(dek)" filename)
+    (re.split r"(.*/)?([^\[\]\(\)]+)(\[v[^\[\]\(\)]+\])?((\([^\[\]\(\)]+\))*)\.(dek)" filename)
     [2 3 4 6])
    (except [e IndexError] [])))
 (defn parse-filename [filename]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -742,36 +742,59 @@
   (print "Deken" version)
 
   (setv arg-parser
-        (apply argparse.ArgumentParser [] {"prog" "deken" "description" "Deken is a build tool for Pure Data externals."}))
-  (setv arg-subparsers (apply arg-parser.add_subparsers [] {"help" "-h for help." "dest" "command" "metavar" "{package,upload}"}))
+        (apply argparse.ArgumentParser []
+               {"prog" "deken"
+                "description" "Deken is a build tool for Pure Data externals."}))
+  (setv arg-subparsers (apply arg-parser.add_subparsers []
+                              {"help" "-h for help."
+                               "dest" "command"
+                               "metavar" "{package,upload}"}))
   (setv arg-package (apply arg-subparsers.add_parser ["package"]))
   (setv arg-upload (apply arg-subparsers.add_parser ["upload"]))
   (apply arg-subparsers.add_parser ["install"])
   (apply arg-subparsers.add_parser ["upgrade"])
   (apply arg-subparsers.add_parser ["update"])
-  (apply arg-parser.add_argument ["--version"] {"action" "version" "version" version "help" "Outputs the version number of Deken."})
+  (apply arg-parser.add_argument ["--version"]
+         {"action" "version"
+          "version" version
+          "help" "Outputs the version number of Deken."})
   (apply arg-package.add_argument ["source"]
          {"nargs" "+"
-                  "metavar" "SOURCE"
-                  "help" "The path to a directory of externals, abstractions, or GUI plugins to be packaged."})
-  (apply arg-package.add_argument ["--version" "-v"] {"help" "A library version number to insert into the package name."
-                                                             "default" None
-                                                             "required" False})
-  (apply arg-package.add_argument ["--dekformat"] {"help" "Override the deken packaging format (DEFAULT: 1)."
-                                                   "default" 1
-                                                   "required" False})
-  (apply arg-upload.add_argument ["source"] {"nargs" "+"
-                                                     "metavar" "PACKAGE"
-                                                     "help" "The path to a package file to be uploaded, or a directory which will be packaged first automatically."})
-  (apply arg-upload.add_argument ["--version" "-v"] {"help" "A library version number to insert into the package name, in case a package is created."
-                                                            "default" None
-                                                            "required" False})
-  (apply arg-upload.add_argument ["--destination" "-d"] {"help" "The destination folder to upload the package to (DEFAULT: /Members/USER/software/PKGNAME/VERSION/)." "default" "" "required" False})
-  (apply arg-upload.add_argument ["--ask-password" "-P"] {"action" "store_true" "help" "Ask for upload password (rather than using password-manager." "default" "" "required" False})
-  (apply arg-upload.add_argument ["--no-source-error"] {"action" "store_true" "help" "Force-allow uploading of packages without sources." "required" False})
-  (apply arg-upload.add_argument ["--dekformat"] {"help" "Override the deken packaging format, in case a package is created. (DEFAULT: 1)."
-                                                  "default" 1
-                                                  "required" False})
+          "metavar" "SOURCE"
+          "help" "The path to a directory of externals, abstractions, or GUI plugins to be packaged."})
+  (apply arg-package.add_argument ["--version" "-v"]
+         {"help" "A library version number to insert into the package name."
+          "default" None
+          "required" False})
+  (apply arg-package.add_argument ["--dekformat"]
+         {"help" "Override the deken packaging format (DEFAULT: 1)."
+          "default" 1
+          "required" False})
+  (apply arg-upload.add_argument ["source"]
+         {"nargs" "+"
+          "metavar" "PACKAGE"
+          "help" "The path to a package file to be uploaded, or a directory which will be packaged first automatically."})
+  (apply arg-upload.add_argument ["--version" "-v"]
+         {"help" "A library version number to insert into the package name, in case a package is created."
+          "default" None
+          "required" False})
+  (apply arg-upload.add_argument ["--dekformat"]
+         {"help" "Override the deken packaging format, in case a package is created. (DEFAULT: 1)."
+          "default" 1
+          "required" False})
+  (apply arg-upload.add_argument ["--destination" "-d"]
+         {"help" "The destination folder to upload the package to (DEFAULT: /Members/USER/software/PKGNAME/VERSION/)."
+          "default" ""
+          "required" False})
+  (apply arg-upload.add_argument ["--ask-password" "-P"]
+         {"action" "store_true"
+          "help" "Ask for upload password (rather than using password-manager."
+          "default" ""
+          "required" False})
+  (apply arg-upload.add_argument ["--no-source-error"]
+         {"action" "store_true"
+          "help" "Force-allow uploading of packages without sources."
+          "required" False})
 
   (setv arguments (.parse_args arg-parser))
   (setv command (.get commands (keyword arguments.command)))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -541,9 +541,14 @@
 (defn archive-extension [rootname]
   (if (or (in "(Windows" rootname) (not (in "(" rootname))) ".zip" ".tar.gz"))
 
-;; automatically pick the correct archiver - windows or "no arch" = zip
+;; v1: all archives are ZIP-files with .dek extension
+;; v0: automatically pick the correct archiver - windows or "no arch" = zip
 (defn archive-dir [directory-to-archive rootname]
-  ((if (= (archive-extension rootname) ".zip") zip-dir tar-dir) directory-to-archive rootname))
+  ((cond
+   [(.endswith rootname ".dek") zip-dir]
+   [(.endswith rootname ".zip") zip-dir]
+   [True tar-dir])
+  directory-to-archive rootname ""))
 
 ;; naive check, whether we have an archive: compare against known suffixes
 (defn is-archive? [filename]
@@ -704,7 +709,7 @@
               (list-comp
                (if (os.path.isdir name)
                  ;; if asking for a directory just package it up
-                 (archive-extra (archive-dir name (make-archive-basename (os.path.normpath name) args.version)))
+                 (archive-extra (archive-dir name (make-archive-name (os.path.normpath name) args.version)))
                  (sys.exit (% "Not a directory '%s'!" name)))
                (name args.source)))
    ;; upload packaged external to pure-data.info

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -526,7 +526,6 @@
             (if (os.path.exists file-path)
               (f.write file-path (os.path.relpath file-path (os.path.join directory-to-zip "..")))))))
   zip-filename)
-(defn dek-dir [directory-to-zip archive-file] (zip-dir directory-to-zip archive-file :extension ".dek"))
 
 ;; tar up the directory
 (defn tar-dir [directory-to-tar archive-file]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -636,12 +636,27 @@
 
 ;; parses a filename into a (pkgname version archs extension) tuple
 ;; missing values are None
+(defn parse-filename0 [filename]
+  (try
+   (get-values
+    ;; parse filename with a regex
+    (re.split r"(.*/)?(.+?)(-v(.+)-)?((\([^\)]+\))+|-)*-externals\.([a-z.]*)" filename)
+    ;; extract only the fields of interested
+    [2 4 5 7])
+   (except [e IndexError] [])))
+(defn parse-filename1 [filename]
+  (try
+   (get-values
+    (re.split r"(.*/)?([^\[\]\(\)]+)(\[[^\[\]\(\)]+\])?((\([^\[\]\(\)]+\))*)\.(dek)" filename)
+    [2 3 4 6])
+   (except [e IndexError] [])))
 (defn parse-filename [filename]
-  (list-comp (get
-                ;; parse filename with a regex
-                (re.split r"(.*/)?(.+?)(-v(.+)-)?((\([^\)]+\))+|-)*-externals\.([a-z.]*)" filename) x)
-                ;; extract only the fields of interested
-             [x [2 4 5 7]]))
+  (list-comp
+   (or x None)
+   [x (or
+       (parse-filename1 filename)
+       (parse-filename0 filename)
+       [None None None None])]))
 (defn filename-to-namever [filename]
   (join-nonempty "/" (get-values (parse-filename filename) [0 1])))
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -562,6 +562,7 @@
     (do
      (setv filename (os.path.basename filepath))
      (setv [pkg ver _ _] (parse-filename filename))
+     (setv ver(.strip ver "[]"))
      (setv url (urlparse destination))
      (setv proto (or url.scheme "https"))
      (setv host (or url.netloc externals-host))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -519,7 +519,7 @@
     (do
      (setv filename (os.path.basename filepath))
      (setv [pkg ver _ _] (parse-filename filename))
-     (setv ver (.strip ver "[]"))
+     (setv ver (.strip (or ver "") "[]"))
      (setv url (urlparse destination))
      (setv proto (or url.scheme "https"))
      (setv host (or url.netloc externals-host))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -63,52 +63,6 @@
 (def version (.get os.environ "DEKEN_VERSION" "<unknown.version>"))
 (def externals-host "puredata.info")
 
-(def elf-arch-types {
-  "EM_NONE" None
-  "EM_386" "i386"
-  "EM_68K" "m68k"
-  "EM_IA_64" "x86_64"
-  "EM_X86_64" "amd64"
-  "EM_ARM" "arm"
-  "EM_M32" "WE32100"
-  "EM_SPARC" "Sparc"
-  "EM_88K" "m88k"
-  "EM_860" "Intel 80860"
-  "EM_MIPS" "MIPS R3000"
-  "EM_S370" "IBM System/370"
-  "EM_MIPS_RS4_BE" "MIPS 4000 big-endian"
-  "EM_AVR" "Atmel AVR 8-bit microcontroller"
-  "EM_AARCH64" "AArch64"
-  "EM_BLAFKIN" "Analog Devices Blackfin"
-  "RESERVED" "RESERVED"})
-
-;; values updated via https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob;f=include/elf/arm.h;hb=HEAD#l93
-(def elf-armcpu [
-   "Pre-v4"
-   "v4"
-   "v4T"
-   "v5T"
-   "v5TE"
-   "v5TEJ"
-   "v6"
-   "v6KZ"
-   "v6T2"
-   "v6K"
-   "v7"
-   "v6_M"
-   "v6S_M"
-   "v7E_M"
-   "v8"
-   "v8R"
-   "v8M_BASE"
-   "v8M_MAIN"
-   ])
-
-(def win-types {
-  "0x014c" ["i386" 32]
-  "0x0200" ["x86_64" 64]
-  "0x8664" ["amd64" 64]})
-
 ;; algorithm to use to hash files
 (def hasher hashlib.sha256)
 (def hash-extension (.pop (hasher.__name__.split "_")))
@@ -271,6 +225,7 @@
                 ;;  (, "EM_NONE", None, None) None
                 ;;  (, "RESERVED", None, None) "RESERVED"
                 })
+  ;; values updated via https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob;f=include/elf/arm.h;hb=HEAD#l93
   (def elf-armcpu [
                    "armPre4"
                    "armv4"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -519,8 +519,8 @@
 (defn zip-file [filename]
   (try (zipfile.ZipFile filename "w" :compression zipfile.ZIP_DEFLATED)
        (except [e RuntimeError] (zipfile.ZipFile filename "w"))))
-(defn zip-dir [directory-to-zip archive-file]
-  (setv zip-filename (+ archive-file ".zip"))
+(defn zip-dir [directory-to-zip archive-file &optional [extension ".zip"]]
+  (setv zip-filename (+ archive-file extension))
   (with [f (zip-file zip-filename)]
         (for [[root dirs files] (os.walk directory-to-zip)]
           (for [file-path (list-comp (os.path.join root file) [file files])]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -528,7 +528,7 @@
   zip-filename)
 
 ;; tar up the directory
-(defn tar-dir [directory-to-tar archive-file]
+(defn tar-dir [directory-to-tar archive-file &optional [extension ".tar.gz"]]
   (setv tar-file (+ archive-file ".tar.gz"))
   (defn tarfilter [tarinfo]
     (setv tarinfo.name (os.path.relpath tarinfo.name (os.path.join directory-to-tar "..")))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -163,7 +163,7 @@
 ;; takes the externals architectures and turns them into a string
 (defn get-architecture-strings [folder]
    (defn _get_archs [archs sep-1 sep-2]
-     (if archs (+ "(" (sep-1.join (set (list-comp (sep-2.join (list-comp (str a) [a arch])) [arch archs]))) ")") ""))
+     (if archs (+ "(" (sep-1.join (sorted (set (list-comp (sep-2.join (list-comp (str a) [a arch])) [arch archs])))) ")") ""))
    (_get_archs (get-externals-architectures folder) ")(" "-"))
 
 ;; check if a particular file has an extension in a set
@@ -182,7 +182,7 @@
 
 ;; examine a folder for externals and return the architectures of those found
 (defn get-externals-architectures [folder]
-  (sum (sorted (+
+  (sum (+
     (if (test-extensions-under-dir folder [".c" ".cpp" ".C" ".cxx" ".cc"])
         [[["Sources"]]] [])
     (list-comp (cond
@@ -192,7 +192,7 @@
       [(re.search "\.(dll|m_[^.]*)$" f) (get-windows-archs (os.path.join folder f))]
       [True []])
     [f (os.listdir folder)]
-    (os.path.exists (os.path.join folder f))))) []))
+    (os.path.exists (os.path.join folder f)))) []))
 
 ; class_new -> t_float=float; class_new64 -> t_float=double
 (defn classnew-to-floatsize [fun]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -162,9 +162,16 @@
 
 ;; takes the externals architectures and turns them into a string
 (defn get-architecture-strings [folder]
-   (defn _get_archs [archs sep-1 sep-2]
-     (if archs (+ "(" (sep-1.join (sorted (set (list-comp (sep-2.join (list-comp (str a) [a arch])) [arch archs])))) ")") ""))
-   (_get_archs (get-externals-architectures folder) ")(" "-"))
+  (defn _get_archs [archs]
+    (print archs)
+     (if archs
+       (+
+        "("
+        (.join ")(" (list-comp a [a (sorted (set archs))] (!= a "Sources")))
+        ")"
+        (if (in "Sources" archs) "(Sources)" ""))
+         ""))
+   (_get_archs (list-comp (.join "-" (list-comp (str parts) [parts arch])) [arch (get-externals-architectures folder)])))
 
 ;; check if a particular file has an extension in a set
 (defn test-extensions [filename extensions]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -83,8 +83,7 @@
   "RESERVED" "RESERVED"})
 
 ;; values updated via https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob;f=include/elf/arm.h;hb=HEAD#l93
-(def arm-cpu-arch
-  [
+(def elf-armcpu [
    "Pre-v4"
    "v4"
    "v4T"
@@ -245,7 +244,7 @@
                   (.index (arm-section.data) aeabi)
                   (.pop (.split (arm-section.data) aeabi))))
   (if data
-    (get arm-cpu-arch (byte-to-int (get (get (.split
+    (get elf-armcpu (byte-to-int (get (get (.split
                                               (cut-slice data 7 None)
                                               (str-to-bytes "\x00") 1) 1) 1)))))
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -186,10 +186,10 @@
     (if (test-extensions-under-dir folder [".c" ".cpp" ".C" ".cxx" ".cc"])
         [[["Sources"]]] [])
     (list-comp (cond
-      [(test-extensions f [".pd_linux" ".l_ia64" ".l_i386" ".l_arm" ".so"]) (get-elf-archs (os.path.join folder f) "Linux")]
-      [(test-extensions f [".pd_freebsd" ".b_i386"]) (get-elf-archs (os.path.join folder f) "FreeBSD")]
-      [(test-extensions f [".pd_darwin" ".d_fat" ".d_ppc"]) (get-mach-archs (os.path.join folder f))]
-      [(test-extensions f [".m_i386" ".dll"]) (get-windows-archs (os.path.join folder f))]
+      [(re.search "\.(pd_linux|so|l_[^.]*)$" f) (get-elf-archs (os.path.join folder f) "Linux")]
+      [(re.search "\.(pd_freebsd|b_[^.]*)$" f) (get-elf-archs (os.path.join folder f) "FreeBSD")]
+      [(re.search "\.(pd_darwin|d_[^.]*)$" f) (get-mach-archs (os.path.join folder f))]
+      [(re.search "\.(dll|m_[^.]*)$" f) (get-windows-archs (os.path.join folder f))]
       [True []])
     [f (os.listdir folder)]
     (os.path.exists (os.path.join folder f))))) []))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -562,7 +562,7 @@
     (do
      (setv filename (os.path.basename filepath))
      (setv [pkg ver _ _] (parse-filename filename))
-     (setv ver(.strip ver "[]"))
+     (setv ver (.strip ver "[]"))
      (setv url (urlparse destination))
      (setv proto (or url.scheme "https"))
      (setv host (or url.netloc externals-host))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -527,6 +527,7 @@
             (if (os.path.exists file-path)
               (f.write file-path (os.path.relpath file-path (os.path.join directory-to-zip "..")))))))
   zip-filename)
+(defn dek-dir [directory-to-zip archive-file] (zip-dir directory-to-zip archive-file :extension ".dek"))
 
 ;; tar up the directory
 (defn tar-dir [directory-to-tar archive-file]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -129,7 +129,7 @@
 
 ;; convert a string into bool, based on the string value
 (defn str-to-bool [s] (and (not (nil? s)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
-
+;; convert a single byte (e.g. bytes('\x01\x02')[0]) to an integer
 (defn byte-to-int [b] (try (ord b) (except [e TypeError] (int b))))
 
 ;; join non-empty elements

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -614,7 +614,8 @@
                                (if version (% "-v%s-" version) "")
                                archs
                                "-externals"
-                               (archive-extension archs))]))
+                               (archive-extension archs))]
+     [True (sys.exit (% "Unknown dekformat '%s'" filenameversion))]))
   (do-make-name
    (os.path.basename folder)
    (cond [(nil? version) (sys.exit

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -423,7 +423,7 @@
                             (dict-merge {} (if gnupghome {"gnupghome" gnupghome}))
                             (if use-agent {"use_agent" True})))
                     "decode_errors" "replace")
-              (except [e OSError] (gpg-unavail-error "init" e))))
+               (except [e OSError] (gpg-unavail-error "init" e))))
         (if gpg (do
           (setv [keyid uid] (list-comp (try-get (gpg-get-key gpg) _ None) [_ ["keyid" "uids"]]))
           (setv uid (try-get uid 0 None))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -712,11 +712,14 @@
    :package (fn [args]
               ;; are they asking to package a directory?
               (list-comp
-               (if (os.path.isdir name)
-                 ;; if asking for a directory just package it up
-                 (archive-extra (archive-dir name (make-archive-name (os.path.normpath name) args.version)))
-                 (sys.exit (% "Not a directory '%s'!" name)))
-               (name args.source)))
+                (if (os.path.isdir name)
+                    ;; if asking for a directory just package it up
+                    (archive-extra
+                      (archive-dir
+                        name
+                        (make-archive-name (os.path.normpath name) args.version (int args.dekformat))))
+                    (sys.exit (% "Not a directory '%s'!" name)))
+                (name args.source)))
    ;; upload packaged external to pure-data.info
    :upload (fn [args]
              (setv username (or (get-config-value "username") (prompt-for-value "username")))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -318,9 +318,8 @@
                [floatsize (get-elf-floatsizes elffile)]
                floatsize))
   (try (do
-        (import [elftools.elf.elffile [ELFFile]])
-        (do-get-elf-archs (ELFFile (open filename :mode "rb")) oshint)
-        )
+         (import [elftools.elf.elffile [ELFFile]])
+         (do-get-elf-archs (ELFFile (open filename :mode "rb")) oshint))
        (except [e Exception] (or None (list)))))
 
 

--- a/developer/requirements.txt
+++ b/developer/requirements.txt
@@ -1,10 +1,10 @@
 hy==0.12.1
 easywebdav==1.2.0
 pyelftools==0.24
-macholib==1.8
+macholib==1.9
 pefile==2017.11.5
 python-gnupg==0.4.1
-keyring==10.4.0
+keyring==10.6.0
 ndg_httpsclient==0.4.3
 pyasn1==0.1.9
 pyOpenSSL==16.2.0

--- a/developer/requirements.txt
+++ b/developer/requirements.txt
@@ -2,6 +2,7 @@ hy==0.12.1
 easywebdav==1.2.0
 pyelftools==0.24
 macholib==1.8
+pefile==2017.11.5
 python-gnupg==0.4.1
 keyring==10.4.0
 ndg_httpsclient==0.4.3


### PR DESCRIPTION
this WIP is intended to get the architecture strings right and to unify the file-format


### architecture string:
- Operating System
- CPU
- floatsize

e.g. `Darwin-arm64-32` is a binary for `macOS` running on `arm64` (the 64bit version of ARM) with a Pd-float-size of `32bits`.

### arch-string deken cmdline tool
- use the same CPU-strings on all platforms (e.g. `amd64` instead of `x86_64`)
- float-size detection
  (possible implementation: `class_new` indicates 32bit numbers, and `class_new64` indicates 64bit numbers. this requires https://github.com/pure-data/pure-data/pull/300 to be merged into Pd.
- use more libraries (e.g. `pefile` for W32 PE files) instead of parsing binary code
- support many more archs (e.g. `Linux-s390x`)

### file(name) format
- ZIP format (on all platforms)
- `.dek` extension
- format: `${library}[${version}](${arch})(${arch}...).dek` (see #161)
  e.g. `bandlimited[v1.0.0](Darwin-i386-32)(Darwin-x86_64-32)(Linux-amd64-32).dek`
- ...
- TODO: a consistent filename for the object-list files

### plugin support
- be strict with the floatsize when considering a `.dek` file (as opposed to
- ...