### PR TITLE
automatically generate objectlists

### DIFF
--- a/developer/README.md
+++ b/developer/README.md
@@ -32,6 +32,20 @@ These builds are snaphots of the latest development branch of `deken`.
 If they don't work for you, you might want to check the [releases page](https://github.com/pure-data/deken/releases)
 for downloads that have been tested by humans.
 
+## Show help ##
+
+~~~sh
+$ deken -h
+~~~
+
+## Upgrade ##
+
+To run a self-upgrade (not supported on all platforms), simply do:
+
+~~~sh
+$ deken upgrade
+~~~
+
 ## Create and Upload a package ##
 
 You have a directory containing your compiled externals object files called
@@ -41,13 +55,17 @@ This command will create a file like `my_external[v0.1](Linux-amd64-64).dek`
 and upload it to your account on <https://puredata.info/> where the search plugin
 can find it:
 
-	$ deken package -v 0.1 my_external
-	$ deken upload "my_external[v0.1](Linux-amd64-64).dek"
+~~~sh
+$ deken package -v 0.1 my_external
+$ deken upload "my_external[v0.1](Linux-amd64-64).dek"
+~~~
 
 You can also just call the 'upload' directly and it will call the package
 command for you in one step:
 
-	$ deken upload -v 0.1 my_external
+~~~sh
+$ deken upload -v 0.1 my_external
+~~~
 
 The upload step will also generate a .sha256 checksum file and upload it along
 with the dek file.
@@ -162,14 +180,43 @@ For uploading a Source package along with binary packages, you can upload one
 package file with multiple archs (including a "Sources" arch) or multiple package
 files (one for the "Sources" arch).
 
-    deken upload frobnozzel(Windows-i386-32)(Sources).dek
-    deken upload foobar[v0.1](Linux-x86_64-32).dek foobar[v0.1](Sources).dek
+~~~sh
+$ deken upload frobnozzel(Windows-i386-32)(Sources).dek
+$ deken upload foobar[v0.1](Linux-x86_64-32).dek foobar[v0.1](Sources).dek
+~~~
 
-## Upgrade ##
+## objectlists
+Sometimes the user only knows the object they need, not the library.
+Therefore, a search initiated via the `deken-plugin` (Pd's package manager) also
+searches for *objects*.
+For this to work, the infrastructure must know which objects are contained in a
+library; which is done via an objectlist file.
 
-	$ deken upgrade
-	... self upgrades the scripts ...
+The objectlist file has one line per object, with the object-name at the beginning,
+followed by a TAB (`\t`) and a short (single-line) description of the object.
 
-## Show help ##
+~~~
+frobnofy	frobfurcate a bugle of numbers
+frobnofy~	signal frobfurcation
+~~~
 
-	$ deken -h
+The objectlist file has the same name as the package with a `.txt` appended.
+E.g. if your library is called `frobnozzel(Windows-i386-32)(Sources).dek`, the
+objectlist would have the name `frobnozzel(Windows-i386-32)(Sources).dek.txt`
+
+`deken` will try to automatically generate an objectlist file for a package.
+It looks for all "*-help.pd" files in the library directory, and creates an
+entry in the objectlists for each. The short description is set to a generic one.
+
+You can provide your own (manually maintained) objectlist file via the
+`--objects`  flag:
+
+~~~sh
+$ deken package --objects mylist.txt my_external
+~~~
+
+To prevent the creation/use of an objectlist file, pass an empty string
+
+~~~sh
+$ deken package --objects "" my_external
+~~~

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -472,10 +472,10 @@
     (try
      (list-comp f [f (.namelist (zipfile.ZipFile archive "r"))])
      (except [e Exception] (log.debug e))))
-  (defn get-files-from-dir [directory]
-    (list-comp
-     f
-     [f (chain.from_iterable (list-comp files [(, root dirs files) (os.walk directory)]))]))
+  (defn get-files-from-dir [directory &optional [recursive False]]
+    (if recursive
+      (list-comp f [f (chain.from_iterable (list-comp files [(, root dirs files) (os.walk directory)]))])
+      (list-comp x [x (os.listdir directory)] (os.path.isfile (os.path.join directory x)))))
   (defn genobjs [input]
     (list-comp (% "%s\tDEKEN GENERATED\n" (slice (os.path.basename f) 0 -8)) [f input] (f.endswith "-help.pd")))
   (defn readobjs [input]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -732,12 +732,12 @@
 
 
 ;; create additional files besides archive: hash-file and gpg-signature
-(defn archive-extra [zipfile]
+(defn archive-extra [dekfile]
   "create additional files besides archive: hash-file and GPG-signature"
-  (log.info (% "Packaging %s" zipfile))
-  (hash-sum-file zipfile)
-  (gpg-sign-file zipfile)
-  zipfile)
+  (log.info (% "Packaging %s" dekfile))
+  (hash-sum-file dekfile)
+  (gpg-sign-file dekfile)
+  dekfile)
 
 ;; parses a filename into a (pkgname version archs extension) tuple
 ;; missing values are None

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -85,8 +85,7 @@
     ~@(if (runs? (nil? None)) []
          [`(defmacro nil? [x] `(= ~x None))])
     ;; in hy-0.12 'slice' has been replaced with 'cut'
-    ~@(if (runs? (slice [])) []
-         [`(defmacro slice [&rest args] `(cut ~@args))])
+    ~@(if (runs? (cut [])) [`(defmacro slice [&rest args] `(cut ~@args))])
     ;; apply has been removed from hy-0.14
     ~@(if (runs? (apply (fn []))) []
          [`(defmacro apply [f &optional (args []) (kwargs {})]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -459,7 +459,7 @@
     "Please enter %s %s:: ")
       (, (name.upper) config-file-path name name forstring))))
 
-(defn make-objects-file [dekfilename objfile]
+(defn make-objects-file [dekfilename objfile &optional [warn-exists True]]
   "generate object-list for <filename> from <objfile>"
   ;; dekfilename exists: issue a warning, and don't overwrite it
   ;; objfile=='' don't create an objects-file
@@ -508,7 +508,8 @@
   (if (os.path.exists dekfilename)
     (do ;; already exists
      (log.info (% "objects file '%s' already exists" dekfilename))
-     (log.warn (% "delete '%s' to re-generate objects file" dekfilename))
+     (if warn-exists
+       (log.warn (% "WARNING: delete '%s' to re-generate objects file" dekfilename)))
      dekfilename)
     (do-make-objects-file dekfilename objfile)))
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -917,6 +917,10 @@
            {"help" "A library version number to insert into the package name (in case the package is created)."
             "default" None
             "required" False})
+    (apply parser.add_argument ["--objects"]
+           {"help" "Specify a tsv-file that lists all the objects of the library (DEFAULT: generate it)."
+            "default" None
+            "required" False})
     (apply parser.add_argument ["--dekformat"]
            {"help" "Override the deken packaging format, in case the package is created (DEFAULT: 0)."
             "default" 1

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -209,7 +209,6 @@
 (defn get-architecture-string [folder]
   "get architecture-string for all Pd-binaries in the folder"
   (defn _get_archs [archs]
-    (print "ARCHS: " archs)
     (if archs
        (+
         "("

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -750,6 +750,7 @@
   (log.info (% "Uploading package '%s'" pkg))
   (upload-file (hash-sum-file pkg) destination username password)
   (upload-file pkg destination username password)
+  (upload-file (make-objects-file pkg None False) destination username password)
   (upload-file (gpg-sign-file pkg) destination username password)
   (, username password))
 ;; upload a list of archives (with aux files)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -504,6 +504,7 @@
         (if (binary-file? objfilename)
           []
           (readobjs objfilename))))]))
+  (setv dekfilename (% "%s.txt" dekfilename))
   (if (os.path.exists dekfilename)
     (do ;; already exists
      (log.info (% "objects file '%s' already exists" dekfilename))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -474,7 +474,9 @@
   (defn get-files-from-dir [directory &optional [recursive False]]
     (if recursive
       (list-comp f [f (chain.from_iterable (list-comp files [(, root dirs files) (os.walk directory)]))])
-      (list-comp x [x (os.listdir directory)] (os.path.isfile (os.path.join directory x)))))
+      (try
+       (list-comp x [x (os.listdir directory)] (os.path.isfile (os.path.join directory x)))
+       (except [e OSError] []))))
   (defn genobjs [input]
     (list-comp (% "%s\tDEKEN GENERATED\n" (slice (os.path.basename f) 0 -8)) [f input] (f.endswith "-help.pd")))
   (defn readobjs [input]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -799,10 +799,14 @@
 
 
 ;; create additional files besides archive: hash-file and gpg-signature
-(defn archive-extra [dekfile]
+(defn archive-extra [dekfile &optional [objects None]]
   "create additional files besides archive: hash-file and GPG-signature"
   (log.info (% "Packaging %s" dekfile))
   (hash-sum-file dekfile)
+  (if objects
+    (if (dekfile.endswith ".dek")
+      (make-objects-file dekfile objects)
+      (log.warn "object-file generation is only enabled for dekformat>=1...skipping!")))
   (gpg-sign-file dekfile)
   dekfile)
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -92,6 +92,22 @@
             `(~f #* ~args #** ~kwargs))]))))
 (defcompat)
 
+(defn binary-file? [filename]
+  "checks if <filename> contains binary data"
+  ;; files that contain '\0' are considered binary
+  ;; UTF-16 can contain '\0'; but for our purposes, its a binary format :-)
+  (defn contains? [f &optional [needle "\0"]]
+    (setv data (f.read 1024))
+    (cond
+     [(not data) False]
+     [(in needle data) True]
+     [True (contains? f needle)]))
+  (try
+   (with [f (open filename "rb")]
+         (contains? f (str-to-bytes "\0")))
+   (except [e Exception]
+     (log.debug e))))
+
 (defn str-to-bytes [s]
   "convert a string into bytes"
   (try (bytes s) (except [e TypeError] (bytes s "utf-8"))))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -928,7 +928,8 @@
                         (make-archive-name
                           (os.path.normpath name)
                           args.version
-                          (int-dekformat args.dekformat))))
+                          (int-dekformat args.dekformat)))
+                      (if (nil? args.objects) name args.objects))
                     (fatal (% "Not a directory '%s'!" name)))
                 (name args.source)))
    ;; upload packaged external to pure-data.info

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -459,13 +459,13 @@
     "Please enter %s %s:: ")
       (, (name.upper) config-file-path name name forstring))))
 
-(defn make-objects-file [dekfilename objfile1 objfile2]
-  "uses <objfile1> as an object-list <filename> or generate one from <objfile2>."
+(defn make-objects-file [dekfilename objfile]
+  "generate object-list for <filename> from <objfile>"
   ;; dekfilename exists: issue a warning, and don't overwrite it
-  ;; objfile1=='' don't create an objects-file
-  ;; objfile1==None generate from <objfile2>
-  ;; objfile1==zip-file extract from zip-file
-  ;; objfile1==TSV-file use directly (actually, we only check whether the file seems to not be binary)
+  ;; objfile=='' don't create an objects-file
+  ;; objfile==None generate from <objfile2>
+  ;; objfile==zip-file extract from zip-file
+  ;; objfile==TSV-file use directly (actually, we only check whether the file seems to not be binary)
   (defn get-files-from-zip [archive]
     (import zipfile)
     (try
@@ -509,7 +509,7 @@
      (log.info (% "objects file '%s' already exists" dekfilename))
      (log.warn (% "delete '%s' to re-generate objects file" dekfilename))
      dekfilename)
-    (do-make-objects-file dekfilename (if (nil? objfile1) objfile2 objfile1))))
+    (do-make-objects-file dekfilename objfile)))
 
 ;; calculate the sha256 hash of a file
 (defn hash-file [file hashfn &optional [blocksize 65535]]


### PR DESCRIPTION
this PR implements the automatic generation of object-list files.
Closes: #190 

By default, it will scan the library directory (or the package file) for help-patches (`*-help.pd`), and add an entry for each help-patch.

alternatively, the user can pass a manually maintained object-list file:

     deken package -v 3.14 --objects myobjectlist.txt path/to/mylibrary/

or a folder to be searched for help-patches:

     deken package -v 3.14 --objects library/with/same/objects/ path/to/mylibrary/

or a previously made deken package:

     deken package -v 3.14 --objects "mylibrary[v2.718].dek" path/to/mylibrary/

to prevent the automatic creation of an object-list file, just set the objects to an empty string:

     deken package -v 3.14 --objects "" path/to/mylibrary/


Like always, this also works witch `upload` instead of `package` as well.


If there's already an object-list file of the same name, no new file will be created.