### PR TITLE
Hy-1.0a4 compatibility

### DIFF
--- a/.git-ci/appveyor.yml
+++ b/.git-ci/appveyor.yml
@@ -6,12 +6,12 @@ configuration: Release
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6"
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
 
 install:

--- a/.git-ci/gitlab-iem.yml
+++ b/.git-ci/gitlab-iem.yml
@@ -35,7 +35,7 @@ variables:
     - echo "${DEKEN_VERSION}"
     - ${PYTHON} -m pip install --upgrade pip
     - ${PYTHON} -m pip install ${PIPFLAGS} -r developer/requirements.txt
-    - ${PYTHON} -m pip install ${PIPFLAGS} pyinstaller
+    - ${PYTHON} -m pip install ${PIPFLAGS} pyinstaller~=5.0
     - for d in ~/Library/Python/*/bin; do test -d "${d}" && PATH=${PATH}:${d}; done || true
     - echo $PATH
     - (cd developer; pyinstaller deken.spec)

--- a/.git-ci/gitlab-iem.yml
+++ b/.git-ci/gitlab-iem.yml
@@ -35,7 +35,7 @@ variables:
     - echo "${DEKEN_VERSION}"
     - ${PYTHON} -m pip install --upgrade pip
     - ${PYTHON} -m pip install ${PIPFLAGS} -r developer/requirements.txt
-    - ${PYTHON} -m pip install ${PIPFLAGS} pyinstaller~=4.3.0
+    - ${PYTHON} -m pip install ${PIPFLAGS} pyinstaller
     - for d in ~/Library/Python/*/bin; do test -d "${d}" && PATH=${PATH}:${d}; done || true
     - echo $PATH
     - (cd developer; pyinstaller deken.spec)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -768,7 +768,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   "verify that the hash if the <filename> file is the same as stored in the <hashfilename>"
   (import hashlib)
   (defn filename2algo [filename]
-    (cut (get (os.path.splitext filename) 1) 1))
+    (cut (get (os.path.splitext filename) 1) 1 None))
   (setv hashfilename (or hashfilename (+ filename ".sha256")))
   (try
     (= (hash-file (open filename :mode "rb" :buffering blocksize)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -46,7 +46,7 @@
 (import io [StringIO])
 (import urllib.parse [urlparse])
 
-(require hy.contrib.loop)
+;(require hy.contrib.loop)
 
 ;; setup logging
 (setv log (logging.getLogger "deken"))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1740,15 +1740,16 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
       :default 1
       :required False)
     (parser.add_argument
-      "--no-sign-gpg"
-      :help "Do not sign the package (DEFAULT: False)."
-      :action "store_true"
-      :required False)
-    (parser.add_argument
       "--sign-gpg"
       :help "Sign the package (DEFAULT: True)."
       :action "store_false"
       :dest "no_sign_gpg"
+      :required False)
+    (parser.add_argument
+      "--no-sign-gpg"
+      :help "Do not sign the package."
+      :action "store_true"
+      :default None
       :required False))
   (defn add-noverify-flags [parser]
     (parser.add_argument

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -780,17 +780,19 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                 (hashlib.new algorithm)
                 blocksize))
 
-(defn hash-verify-file [filename [hashfilename None] [blocksize -1]]
+(defn hash-verify-file [filename [hashfilename None] [blocksize -1] [algorithm None]]
   "verify that the hash of the <filename> file is the same as stored in the <hashfilename>"
   (import hashlib)
   (defn filename2algo [filename]
     (cut (get (os.path.splitext filename) 1) 1 None))
   (setv hashfilename (or hashfilename (+ filename ".sha256")))
+  (setv algorithm (or algorithm (filename2algo hashfilename)))
   (try
     (= (hash-file (open filename :mode "rb" :buffering blocksize)
-                  (hashlib.new (filename2algo hashfilename)))
+                  (hashlib.new algorithm))
        (.strip (get (.split (.read (open hashfilename "r"))) 0)))
-    (except [e (, OSError TypeError ValueError)] None)))
+    (except [e (, OSError TypeError ValueError)]
+            (log_exception))))
 
 ;; handling GPG signatures
 (try (import gnupg)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1682,7 +1682,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                   (if args.all
                       (if args.fix (fatal "'--all' and named fixes are exclusive. Choose one.")
                                    (setv args.fix fixnames)))
-                  (if args.fix (lfor f args.fix (try-call (.get fixes (keyword f))))
+                  (if args.fix (lfor f args.fix (try-call (.get fixes (hy.model.Keyword f))))
                                (fatal (% "Known systemfixes: %s" (.join "," fixnames)) 0)))
        :update upgrade
        :upgrade upgrade})
@@ -2020,7 +2020,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     :nargs "*"
     :help "run the named system-fix")
   (setv arguments (parse-args arg-parser))
-  (setv command (.get commands (keyword arguments.command)))
+  (setv command (.get commands (hy.models.Keyword arguments.command)))
   ;;(print "Deken" version)
   (log.debug (.join " " sys.argv))
   (if command (command arguments) (.print_help arg-parser)))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1694,7 +1694,7 @@ returns a tuple of a (list of verified files) and the number of failed verificat
                   (setv downloaded-pkgs
                         (if pkgs
                             (download-verified
-                                   (categorize-search-terms (.difference pkgs (set file-pkgs)) True False)
+                                   (categorize-search-terms pkgs :objects False)
                                    :architecture (or args.architecture None)
                                    :verify-gpg (and (not args.ignore-gpg) (if (or args.ignore-missing args.ignore-missing-gpg) None True))
                                    :verify-hash (and (not args.ignore-hash) (if (or args.ignore-missing args.ignore-missing-hash) None True))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -774,8 +774,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     (= (hash-file (open filename :mode "rb" :buffering blocksize)
                   (hashlib.new (filename2algo hashfilename)))
        (.strip (get (.split (.read (open hashfilename "r"))) 0)))
-    (except [e OSError] None)
-    (except [e TypeError] None)))
+    (except [e (, OSError TypeError ValueError)] None)))
 
 ;; handling GPG signatures
 (try (import gnupg)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1389,7 +1389,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
 
 (defn find [args] ;; TODO: this used to be '&optional args'
   "searches the server for deken-packages and prints the results"
-  (defn print-result [result [index None]]
+  (defn print-result [result]
     (setv url (get result "URL"))
     (setv description (get result "description"))
     (print (% "%s/%s uploaded by %s on %s for %s"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -34,6 +34,8 @@
 ;; IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ;; THE POSSIBILITY OF SUCH DAMAGE.
 
+(import hy.pyops [>=])
+
 (import sys)
 (import os)
 (import re)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1836,6 +1836,10 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
           (not (str-to-bool (get-config-value "sign_gpg" True))))
       (do (global gpg-sign-file)
           (defn gpg-sign-file [filename])))
+    (if (and (hasattr args "debug") args.debug)
+        (do
+         (global log_exception)
+         (defn log_exception [] (log.exception ""))))
     args)
 
   (setv arg-parser
@@ -1904,6 +1908,11 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     :help "Lower verbosity"
     :action "count"
     :default 0)
+  (arg-parser.add_argument
+    "--debug"
+    :help "Enable debugging output"
+    :action "store_true"
+    :required False)
   (arg-parser.add_argument
     "--version"
     :action "version"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -495,11 +495,11 @@
                    "ELFOSABI_IRIX" "Irix"
                    "ELFOSABI_FREEBSD" "FreeBSD"
                    "ELFOSABI_TRU64" "Tru64"
-                   "ELFOSABI_MODESTO" None
+                   "ELFOSABI_MODESTO" "Modesto" ; Novell Modesto
                    "ELFOSABI_OPENBSD" "OpenBSD"
                    "ELFOSABI_OPENVMS" "OpenVMS"
-                   "ELFOSABI_NSK" None
-                   "ELFOSABI_AROS" None
+                   "ELFOSABI_NSK" "NonStop" ; NonStop Kernel
+                   "ELFOSABI_AROS" "AROS" ; AROS Research Operating System (AmigaOS-like)
                    "ELFOSABI_ARM_AEABI" None
                    "ELFOSABI_ARM" None
                    "ELFOSABI_STANDALONE" None})

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -42,9 +42,9 @@
 (import datetime)
 (import logging)
 
-(import [configparser [ConfigParser]])
-(import [io [StringIO]])
-(import [urllib.parse [urlparse]])
+(import configparser [ConfigParser])
+(import io [StringIO])
+(import urllib.parse [urlparse])
 
 (require hy.contrib.loop)
 
@@ -569,7 +569,7 @@
              (get-elf-armcpu (elf-cpu.get (, elffile.header.e_machine elffile.elfclass elffile.little_endian)))
              floatsize)))
   (try (do
-         (import [elftools.elf.elffile [ELFFile]])
+         (import elftools.elf.elffile [ELFFile])
          (do-get-elf-archs (ELFFile (open filename :mode "rb")) oshint))
        (except [e Exception] (or (log.debug e) (list)))))
 
@@ -596,7 +596,7 @@
                    })
   (defn get-macho-arch [macho]
     (defn get-macho-floatsizes [header]
-      (import [macholib.SymbolTable [SymbolTable]])
+      (import macholib.SymbolTable [SymbolTable])
       (list (filter-none
               (lfor (, _ name) (getattr (SymbolTable macho header) "undefsyms")
                     (--pdfunction-to-floatsize-- (.decode name))))))
@@ -606,7 +606,7 @@
         (, "Darwin" (macho-cpu.get header.header.cputype) floatsize)))
     (list (chain.from_iterable (lfor hdr macho.headers (get-macho-headerarchs hdr)))))
   (try (do
-         (import [macholib.MachO [MachO]])
+         (import macholib.MachO [MachO])
          (get-macho-arch (MachO filename)))
        (except [e Exception] (or (log.debug e) (list)))))
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -765,7 +765,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                 blocksize))
 
 (defn hash-verify-file [filename [hashfilename None] [blocksize -1]]
-  "verify that the hash if the <filename> file is the same as stored in the <hashfilename>"
+  "verify that the hash of the <filename> file is the same as stored in the <hashfilename>"
   (import hashlib)
   (defn filename2algo [filename]
     (cut (get (os.path.splitext filename) 1) 1 None))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1479,7 +1479,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                          ".asc"    gpg
                          "GPG-verification failed for '%s'"
                          "GPG-signature '%s' missing for '%s'"))
-  (setv vhash (do-verify hash-verify-file
+  (setv vhash (do-verify (fn [dfile hfile] (hash-verify-file dfile hfile :algorithm "sha256"))
                          dekfile hashfile
                          ".sha256" hash
                          "hashsum mismatch for '%s'"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -50,8 +50,6 @@
 (import itertools [chain])
 (setv flatten chain.from_iterable)
 
-;(require hy.contrib.loop)
-
 ;; setup logging
 (setv log (logging.getLogger "deken"))
 (log.addHandler (logging.StreamHandler))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1527,12 +1527,14 @@ returns a tuple of a (list of verified files) and the number of failed verificat
           (log.info (% "Downloaded: %s" (, pkg)))
           pkg)))
   (setv foundurls
-        (lfor x (find-packages searchterms
+        (if (sum (lfor t ["libraries" "objects"] (len (.get searchterms t []))))
+            (lfor x (find-packages searchterms
                                :architectures architecture
                                :versioncount 1
                                :searchurl search-url)
-              :if (package-uri? (try-get x "URL" ""))
-              (get x "URL")))
+                  :if (package-uri? (try-get x "URL" ""))
+                  (get x "URL"))
+          []))
   (setv urls
         (lfor x (+ foundurls (try-get searchterms "urls" []))
               :if (or

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1468,20 +1468,20 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                    extension
                    fail
                    [errstring "verification of '%s' failed"]
-                   [missstring "verification file of '%s' missing"]]
+                   [missstring "verification file '%s' for '%s' missing"]]
     (verify-result (verifun dekfile
                             (or reffile (+ dekfile extension)))
                    fail
                    (% errstring (, dekfile))
-                   (% missstring (, dekfile))))
+                   (% missstring (, reffile dekfile))))
   (setv vgpg  (do-verify gpg-verify-file  dekfile gpgfile
                          ".asc"    gpg
                          "GPG-verification failed for '%s'"
-                         "GPG-signature missing for '%s'"))
+                         "GPG-signature '%s' missing for '%s'"))
   (setv vhash (do-verify hash-verify-file dekfile hashfile
                          ".sha256" hash
                          "hashsum mismatch for '%s'"
-                         "hash file missing for '%s'"))
+                         "hash file '%s' missing for '%s'"))
   (log.debug (% "GPG-verification : %s" (, vgpg)))
   (log.debug (% "hash-verification: %s" (, vhash)))
   (and vgpg vhash))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -42,12 +42,9 @@
 (import datetime)
 (import logging)
 
-(try (import [configparser [ConfigParser :as SafeConfigParser]])
-     (except [e ImportError] (import [ConfigParser [SafeConfigParser]])))
-(try (import [io [StringIO]])
-     (except [e ImportError] (import [StringIO [StringIO]])))
-(try (import [urllib.parse [urlparse]])
-     (except [e ImportError] (import [urlparse [urlparse]])))
+(import [configparser [ConfigParser :as SafeConfigParser]])
+(import [io [StringIO]])
+(import [urllib.parse [urlparse]])
 
 (require hy.contrib.loop)
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -53,7 +53,7 @@
 (log.addHandler (logging.StreamHandler))
 
 ;; do nothing
-(defn nop [&rest args] "does nothing; returns None" None)
+(defn nop [#* ignored_args] "does nothing; returns None" None)
 
 ;; simple debugging helper: prints an object and returns it
 (defn debug [x] "print the argument and return it" (log.debug x) x)
@@ -153,7 +153,7 @@
   (.join joiner (lfor x elements :if x (str x))))
 
 ;; concatenate dictionaries - hylang's assoc is broken
-(defn dict-merge [dict0 &rest dicts]
+(defn dict-merge [dict0 #* dicts]
   "merge several dictionaries; if a key exists in more than one dict, the latet takes precedence"
   (defn dict-merge-aux [dict0 dicts]
     (for [d dicts] (if d (dict0.update d)))
@@ -190,7 +190,7 @@
   (reduce (fn [a kv] (a.replace #* kv)) repls s))
 
 ;; execute a command inside a directory
-(defn in-dir [destination f &rest args]
+(defn in-dir [destination f #* args]
   "execute a command f(args) inside a directory"
   (setv last-dir (os.getcwd))
   (os.chdir destination)
@@ -239,7 +239,7 @@
 (setv config (read-config (+ "[default]\n" (try (.read (open config-file-path "r"))(except [e Exception] "")))))
 ;; try to obtain a value from environment, then config file, then prompt user
 
-(defn get-config-value [name &rest default]
+(defn get-config-value [name #* default]
   "tries to get a value first from the envvars, then from the config-file and finally falls back to a default"
   (first (filter (fn [x] (not (is x None)))
                  [
@@ -1316,7 +1316,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                      [URL None]
                      [uploader None]
                      [date None]
-                     &rest args]
+                     #* args]
       (setv result
             (dict-merge
               {"description" description

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1690,12 +1690,12 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                         :easywebdav2 (fn []
                                  (import easywebdav2)
                                  (fix-easywebdav2 easywebdav2 :exit None))})
-                  (setv fixnames (lfor k (.keys fixes) (cut (str k) 1)))
+                  (setv fixnames (lfor k fixes k.name))
                   (defn try-call [x] (if x (x)))
                   (if args.all
                       (if args.fix (fatal "'--all' and named fixes are exclusive. Choose one.")
                                    (setv args.fix fixnames)))
-                  (if args.fix (lfor f args.fix (try-call (.get fixes (hy.model.Keyword f))))
+                  (if args.fix (lfor f args.fix (try-call (.get fixes (hy.models.Keyword f))))
                                (fatal (% "Known systemfixes: %s" (.join "," fixnames)) 0)))
        :update upgrade
        :upgrade upgrade})

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -34,7 +34,6 @@
 ;; IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ;; THE POSSIBILITY OF SUCH DAMAGE.
 
-
 (import sys)
 (import os)
 (import re)
@@ -46,6 +45,7 @@
 (import io [StringIO])
 (import urllib.parse [urlparse])
 
+(import itertools [chain])
 (setv flatten chain.from_iterable)
 
 ;(require hy.contrib.loop)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1383,7 +1383,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     (print (% "%s/%s uploaded by %s on %s for %s"
               (,
                (get result "package")
-                 (get result "version")
+                 (or (get result "version") "<unknown.version>")
                  (get result "uploader")
                  (get result "timestamp")
                  (or

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1474,11 +1474,13 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                    fail
                    (% errstring (, dekfile))
                    (% missstring (, reffile dekfile))))
-  (setv vgpg  (do-verify gpg-verify-file  dekfile gpgfile
+  (setv vgpg  (do-verify gpg-verify-file
+                         dekfile gpgfile
                          ".asc"    gpg
                          "GPG-verification failed for '%s'"
                          "GPG-signature '%s' missing for '%s'"))
-  (setv vhash (do-verify hash-verify-file dekfile hashfile
+  (setv vhash (do-verify hash-verify-file
+                         dekfile hashfile
                          ".sha256" hash
                          "hashsum mismatch for '%s'"
                          "hash file '%s' missing for '%s'"))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -757,11 +757,11 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   (defn do-hash-file [filename hashfilename hasher blocksize]
     (.write (open hashfilename :mode "w")
             (hash-file (open filename :mode "rb" :buffering blocksize)
-                       (hasher))
+                       hasher))
     hashfilename)
   (do-hash-file filename
                 (% "%s.%s" (, filename algorithm))
-                (.get hashlib.__dict__ algorithm)
+                (hashlib.new algorithm)
                 blocksize))
 
 (defn hash-verify-file [filename [hashfilename None] [blocksize -1]]
@@ -772,7 +772,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   (setv hashfilename (or hashfilename (+ filename ".sha256")))
   (try
     (= (hash-file (open filename :mode "rb" :buffering blocksize)
-                  ((.get hashlib.__dict__ (filename2algo hashfilename))))
+                  (hashlib.new (filename2algo hashfilename)))
        (.strip (get (.split (.read (open hashfilename "r"))) 0)))
     (except [e OSError] None)
     (except [e TypeError] None)))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -567,7 +567,7 @@
         (defn armcpu-from-aeabi-helper [data]
           (if data
               (get elf-armcpu (byte-to-int (get (get (.split
-                                                       (cut data 7)
+                                                       (cut data 7 None)
                                                        (str-to-bytes "\x00") 1) 1) 1)))))
         (armcpu-from-aeabi-helper (and (arm.startswith (str-to-bytes "A")) (arm.index aeabi) (.pop (arm.split aeabi)))))
       (or
@@ -1172,7 +1172,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                                 "-externals"
                                 (archive-extension archs))]
       [True (fatal (% "Unknown dekformat '%s'" filenameversion))]))
-  (setv version (if (and version (.startswith version "v")) (cut version 1) version))
+  (setv version (if (and version (.startswith version "v")) (cut version 1 None) version))
   (do-make-name
     (os.path.normpath (os.path.join output-dir (or pkgname (os.path.basename folder))))
     (cond [(is version None)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -196,7 +196,12 @@
 ;; replace multiple words (given as pairs in <repls>) in a string <s>
 (defn replace-words [s repls]
   "replace multiple words (given as pairs in <repls>) in a string <s>"
-  (reduce (fn [a kv] (a.replace #* kv)) repls s))
+  ; https://stackoverflow.com/a/6117124/1169096
+  ;rep = dict((re.escape(k), v) for k, v in rep.iter())
+  ;pattern = re.compile("|".join(rep.keys()))
+  ;text = pattern.sub(lambda m: rep[re.escape(m.group(0))], text)
+  (setv repls (dfor (, k v) repls [(re.escape k) v]))
+  (.sub (re.compile (.join "|" repls)) (fn [m] (get repls (re.escape (.group m 0)))) "/Members/%u/software/%p/%v"))
 
 ;; execute a command inside a directory
 (defn in-dir [destination f #* args]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -59,7 +59,7 @@
 (defn debug [x] "print the argument and return it" (log.debug x) x)
 
 ;; print a fatal error and exit with an error code
-(defn fatal [x &optional [exit 1]]
+(defn fatal [x [exit 1]]
   "print argument as an error message and exit"
   (log.fatal x)
   (if (not (is exit None))
@@ -117,7 +117,7 @@
   "checks if <filename> contains binary data"
   ;; files that contain '\0' are considered binary
   ;; UTF-16 can contain '\0'; but for our purposes, its a binary format :-)
-  (defn contains? [f &optional [needle "\0"]]
+  (defn contains? [f [needle "\0"]]
     (setv data (f.read 1024))
     (cond
       [(not data) False]
@@ -167,7 +167,7 @@
   (setattr obj attr value) obj)
 
 ;; get multiple attributes as list
-(defn get-attrs [obj attributes &optional default]
+(defn get-attrs [obj attributes [default None]]
   "returns a list of values, one for each attr in <attributes>"
   (lfor _ attributes (getattr obj _default)))
 
@@ -177,7 +177,7 @@
   (lfor _ keys (get coll _)))
 
 ;; get a value at an index/key or a default
-(defn try-get [elements index &optional default]
+(defn try-get [elements index [default None]]
   "get a value at an index/key, falling back to a default"
   (try (get elements index)
        (except [e TypeError] default)
@@ -200,7 +200,7 @@
 
 ;; TODO: refactor 'listdir' and 'get-files-from-dir' into a single function
 
-(defn fix-easywebdav2 [pkg &optional
+(defn fix-easywebdav2 [pkg
                        [broken "            for dir_ in dirs:\n                try:\n                    self.mkdir(dir, safe=True, **kwargs)"]
                        [fixed "            for dir_ in dirs:\n                try:\n                    self.mkdir(dir_, safe=True, **kwargs)"]
                        [exit 1]]
@@ -230,7 +230,7 @@
 
 
 ;; read in the config file if present
-(defn read-config [configstring &optional [config-file (ConfigParser)]]
+(defn read-config [configstring [config-file (ConfigParser)]]
   "reads the configuration into a dictionary"
   (try (config-file.read_file (StringIO configstring))
        (except [e AttributeError] (config-file.readfp (StringIO configstring))))
@@ -251,7 +251,7 @@
                   (first default)])))
 
 ;; prompt for a particular config value for externals host upload
-(defn prompt-for-value [name &optional [forstring ""]]
+(defn prompt-for-value [name [forstring ""]]
   "prompt the user for a particular config value (with an explanatory text)"
   ((try raw_input (except [e NameError] input))
     (% (+
@@ -260,7 +260,7 @@
          "Please enter %s %s:: ")
        (, (name.upper) config-file-path name name forstring))))
 
-(defn askpass [&optional [prompt "Password: "]]
+(defn askpass [[prompt "Password: "]]
   """prompt the user for a password"""
   (import getpass)
   (getpass.getpass prompt))
@@ -357,7 +357,7 @@
         ["Sources"]
         [])))
 
-(defn split-archstring [archstring &optional [fixdek0 False]]
+(defn split-archstring [archstring [fixdek0 False]]
   "splits an archstring like '(Linux-amd64-32)(Windows-i686-32)' into a list of arch-tuples"
                                 ; if fixdek0 is True, this forces the floatsize to "32"
   (defn split-arch [arch fixdek0]
@@ -372,7 +372,7 @@
   "convert an architecture-tuple into a string"
   (.join "-" (stringify-tuple arch)))
 
-(defn --archs-default-floatsize-- [&optional [filename None]]
+(defn --archs-default-floatsize-- [[filename None]]
   (defn doit [floatsize filename]
     (log.warning
       (if filename
@@ -397,7 +397,7 @@
   (.union (set (chain.from-iterable (lfor (, (, os cpu) floatsizes) (.items archdict) (lfor fs (or (list (filter bool floatsizes)) [0]) (, os cpu fs))))) others))
 
 ;; takes the externals architectures and turns them into a string)
-(defn get-architecture-string [folder &optional [recurse-subdirs False] [extra-files []]]
+(defn get-architecture-string [folder [recurse-subdirs False] [extra-files []]]
   "get architecture-string for all Pd-binaries in the folder"
   (defn _get_archs [archs]
     (if archs
@@ -429,11 +429,10 @@
 
 ;; examine a folder for externals and return the architectures of those found
 (defn get-externals-architectures [folder
-                                   &optional
                                    [extra-files []]
                                    [recurse-subdirs False]]
   "examine a folder for external binaries (and sources) and return the architectures of those found"
-  (defn listdir [folder &optional [recurse-subdirs True]]
+  (defn listdir [folder [recurse-subdirs True]]
     (if recurse-subdirs
         (lfor (, dirname subdirs filenames) (os.walk folder) f filenames (os.path.join dirname f))
         (lfor f (os.listdir folder) (os.path.join folder f))))
@@ -463,7 +462,7 @@
 
 
 ;; Linux ELF file
-(defn get-elf-archs [filename &optional [oshint "Linux"]]
+(defn get-elf-archs [filename [oshint "Linux"]]
   "guess OS/CPU/floatsize for ELF binaries"
   (setv elf-osabi {
                    "ELFOSABI_SYSV" None
@@ -668,7 +667,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
               "\t" " ") "\n" " "))
 
 
-(defn make-objects-file [dekfilename objfile &optional [warn-exists True]]
+(defn make-objects-file [dekfilename objfile [warn-exists True]]
   "generate object-list for <filename> from <objfile>"
   ;; dekfilename exists: issue a warning, and don't overwrite it
   ;; objfile=='' don't create an objects-file
@@ -679,7 +678,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     (import zipfile)
     (try (.namelist (zipfile.ZipFile archive "r"))
          (except [e Exception] (log.debug e))))
-  (defn get-files-from-dir [directory &optional [recursive False] [full_path False]]
+  (defn get-files-from-dir [directory [recursive False] [full_path False]]
     (if recursive
         (list (chain.from_iterable
                 (lfor (, root dirs files) (os.walk directory) (if full_path
@@ -733,7 +732,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
       (do-make-objects-file dekfilename objfile)))
 
 ;; calculate the sha256 hash of a file
-(defn hash-file [file hashfn &optional [blocksize 65535]]
+(defn hash-file [file hashfn [blocksize 65535]]
   "calculate the hash of a file"
   (setv read-chunk (fn [] (.read file blocksize)))
   (while True
@@ -742,7 +741,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     (hashfn.update buf))
   (hashfn.hexdigest))
 
-(defn hash-sum-file [filename &optional [algorithm "sha256"] [blocksize 65535]]
+(defn hash-sum-file [filename [algorithm "sha256"] [blocksize 65535]]
   "calculates the (sha256) hash of a file and stores it into a separate file"
   (import hashlib)
   (defn do-hash-file [filename hashfilename hasher blocksize]
@@ -756,7 +755,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                 (.get hashlib.__dict__ algorithm)
                 blocksize))
 
-(defn hash-verify-file [filename &optional hashfilename [blocksize 65535]]
+(defn hash-verify-file [filename [hashfilename None] [blocksize 65535]]
   "verify that the hash if the <filename> file is the same as stored in the <hashfilename>"
   (import hashlib)
   (defn filename2algo [filename]
@@ -788,7 +787,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
            )))
      (else
        (do
-         (defn --gpg-unavail-error-- [state &optional ex]
+         (defn --gpg-unavail-error-- [state [ex None]]
            (log.warning (% "GPG %s failed:" state))
            (if ex (log.warning ex))
            (log.warning "Do you have 'gpg' installed?")
@@ -934,7 +933,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
       (fn [libdict] True)))
 
 
-(defn sort-searchresults [libdicts &optional [reverse False]]
+(defn sort-searchresults [libdicts [reverse False]]
   "sort <libdicts> (list of dictionaries)"
   (sorted libdicts
           :reverse reverse
@@ -943,7 +942,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                           (.lower (or (get d "version") ""))
                           (.lower (or (get d "timestamp") ""))))))
 
-(defn filter-older-versions [libdicts &optional [depth 1]]
+(defn filter-older-versions [libdicts [depth 1]]
   "for each library (with a unique 'package' key) in <libdicts> leave only the latest <depth> versions"
   (defn doit [libdicts depth]
     ;; create a dict with <package> keys, and the values being <libdict> lists
@@ -975,7 +974,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   (import zipfile)
   (try (zipfile.ZipFile filename "w" :compression zipfile.ZIP_DEFLATED)
        (except [e RuntimeError] (zipfile.ZipFile filename "w"))))
-(defn zip-dir [directory-to-zip archive-file &optional [extension ".zip"]]
+(defn zip-dir [directory-to-zip archive-file [extension ".zip"]]
   "create a ZIP-archive of a directory"
   (setv zip-filename (+ archive-file extension))
   (with [f (zip-file zip-filename)]
@@ -984,7 +983,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
         (if (os.path.exists file-path)
             (f.write file-path (os.path.relpath file-path (os.path.join directory-to-zip "..")))))))
   zip-filename)
-(defn unzip-file [archive-file &optional [targetdir "."]]
+(defn unzip-file [archive-file [targetdir "."]]
   "extract all members of the zip archive into targetdir"
   (print archive-file)
   (try (do
@@ -995,7 +994,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
        (except [e Exception] (or (log.debug (% "unzipping '%s' failed" (, archive-file))) False))))
 
 ;; tar up the directory
-(defn tar-dir [directory-to-tar archive-file &optional [extension ".tar.gz"]]
+(defn tar-dir [directory-to-tar archive-file [extension ".tar.gz"]]
   "create a (gzipped) TAR archive of a directory"
   (import tarfile)
   (setv tar-file (+ archive-file extension))
@@ -1006,7 +1005,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     (f.add directory-to-tar :filter tarfilter))
   tar-file)
 
-(defn untar-file [archive-file &optional [targetdir "."]]
+(defn untar-file [archive-file [targetdir "."]]
   "extract all members of the tar archive into targetdir"
   (try (do
          (import tarfile)
@@ -1036,7 +1035,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   (test-extensions filename [".dek" ".zip" ".tar.gz" ".tgz"]))
 
 ;; download a file
-(defn download-file [url &optional filename]
+(defn download-file [url [filename None]]
   "downloads a file from <url>, saves it as <filename> (or a sane default); returns the filename or None; makes sure that no file gets overwritten"
   (defn unique-filename [filename]
     (defn unique-filename-number [filename number]
@@ -1150,7 +1149,6 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
 ;; v1: "<pkgname>[v<version>](<arch1>)(<arch2>).dek"
 ;; v0: "<pkgname>-v<version>-(<arch1>)(<arch2>)-externals.tar.gz" (resp. ".zip")
 (defn make-archive-name [folder pkgname version
-                         &optional
                          [filenameversion 1]
                          [recurse-subdirs False]
                          [extra-arch-files []]
@@ -1184,7 +1182,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
 
 
 ;; create additional files besides archive: hash-file and gpg-signature
-(defn archive-extra [dekfile &optional [objects None]]
+(defn archive-extra [dekfile [objects None]]
   "create additional files besides archive: hash-file and GPG-signature"
   (log.info (% "Packaging %s" dekfile))
   (hash-sum-file dekfile)
@@ -1246,7 +1244,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
             (has-sources? p))))
 
 ;; check if sources archs are present by comparing a SET of packagaes and a SET of packages-with-sources
-(defn check-sources [pkgs sources &optional puredata-info-user]
+(defn check-sources [pkgs sources [puredata-info-user None]]
   "bail out if there are no sources on puredata.info yet and we don't currently upload sources"
   (for [pkg pkgs] (if (and
                         (not (in pkg sources))
@@ -1280,7 +1278,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
         "<unknown>"
         (get (.split sys.version) 0))))
 
-(defn categorize-search-terms [terms &optional [libraries True] [objects True]]
+(defn categorize-search-terms [terms [libraries True] [objects True]]
   "splits the <terms> into objects, libraries and versioned-libraries; returns a dict"
   ;; versioned requirements (e.g. 'foo>=3.14') are always libraries, and go into 'libraries' (without the version) and 'versioned-libraries' (as tuples)
   ;; unversioned terms will show up in 'libraries' and/or 'objects', depending on which flag is True
@@ -1314,7 +1312,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
 (defn search [searchurl libraries objects]
   "searches needles in libraries (if True) and objects (if True)"
   (defn parse-tab-separated-values [data]
-    (defn parse-tsv [description &optional
+    (defn parse-tsv [description
                      [URL None]
                      [uploader None]
                      [date None]
@@ -1349,7 +1347,6 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
       (parse-data r.text (get r.headers "content-type"))))
 
 (defn find-packages [searchterms ;; as returned by categorize-search-terms
-                     &optional
                      [architectures []] ;; defaults to 'native'; use '*' for any architecture
                      [versioncount 0]   ;; how many versions of a given library should be returned
                      [searchurl default-searchurl] ;; where to search
@@ -1366,9 +1363,9 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
           x)
     versioncount))
 
-(defn find [&optional args]
+(defn find [args] ;; TODO: this used to be '&optional args'
   "searches the server for deken-packages and prints the results"
-  (defn print-result [result &optional index]
+  (defn print-result [result [index None]]
     (setv url (get result "URL"))
     (setv description (get result "description"))
     (print (% "%s/%s uploaded by %s on %s for %s"
@@ -1404,7 +1401,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     (print-result result)))
 
 ;; instruct the user how to manually upgrade 'deken'
-(defn upgrade [&optional args]
+(defn upgrade [#* args]
   "print a big fat notice about manually upgrading via the webpage"
   (defn open-webpage [page]
     (log.warning
@@ -1425,7 +1422,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
 ;;         False verification failed (e.g. GPG-signature mismatch)
 ;; the 'gpg/hash' arg can modify the result: False: always return True
 ;;                                           None: return True if None
-(defn verify [dekfile &optional gpgfile hashfile [gpg True] [hash True]]
+(defn verify [dekfile [gpgfile None] [hashfile None] [gpg True] [hash True]]
   "verifies a dekfile by checking it's GPG-signature (if possible) the SHA256; if gpg/hash is False, verification failure is ignored, if its None the reference file is allowed to miss"
   (defn verify-result [result fail errstring missstring]
     ;; result==True: OK
@@ -1446,7 +1443,6 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                    reffile
                    extension
                    fail
-                   &optional
                    [errstring "verification of '%s' failed"]
                    [missstring "verification file of '%s' missing"]]
     (verify-result (verifun dekfile
@@ -1467,7 +1463,6 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   (and vgpg vhash))
 
 (defn download-verified [searchterms
-                         &optional
                          [architecture None]
                          [verify-gpg True]
                          [verify-hash True]
@@ -1533,7 +1528,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                     (try (int value)
                          (except [e ValueError]
                            (fatal (% "Illegal dekformat '%s'" value)))))
-                  (defn set-default-floatsize [value &optional [valid [None 0 32 64]]]
+                  (defn set-default-floatsize [value [valid [None 0 32 64]]]
                     (if (in value valid)
                         (do
                           (global default-floatsize)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -34,7 +34,7 @@
 ;; IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 ;; THE POSSIBILITY OF SUCH DAMAGE.
 
-(import hy.pyops [>=])
+(import hy.pyops [>= =])
 
 (import sys)
 (import os)
@@ -923,11 +923,11 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
 (defn parse-requirement [spec]
   "parse a requirement-string "
   ;; spec can be a library, or a library with version, e.g. "library==0.2.1" or "library>=1.2.3"
-  ;; currently the only valid compatrators are ">=" and "=="
+  ;; currently the only valid compatrators are: ">=", "==", "~="
   ;; returns a tuple (library, version, comparator)
-  (setv result (try (get-values (re.split "(.+)([>=]=)(.+)" spec) [1 3 2])
+  (setv result (try (get-values (re.split "(.+)([~>=]=)(.+)" spec) [1 3 2])
                     (except [e IndexError] [spec None None])))
-  (setv (get result 2) (try-get {"==" str.startswith ">=" >=} (get result 2) (fn [a b] True)))
+  (setv (get result 2) (try-get {"~=" str.startswith "==" = ">=" >=} (get result 2) (fn [a b] True)))
   (tuple result))
 
 (defn make-requirement-matcher [parsedspec]

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1824,7 +1824,9 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     (log.setLevel (max 1 (+ logging.WARN (* 10 (- args.quiet args.verbose)))))
     (del args.verbose)
     (del args.quiet)
-    (if (and (hasattr args "no_sign_gpg") args.no-sign-gpg)
+    (if (if (and (hasattr args "no_sign_gpg") (is-not args.no-sign-gpg None))
+            args.no-sign-gpg
+          (not (str-to-bool (get-config-value "sign_gpg" True))))
       (do (global gpg-sign-file)
           (defn gpg-sign-file [filename])))
     args)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1023,7 +1023,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
 
 ;; do we use zip or tar on this archive?
 (defn archive-extension [rootname]
-  "default extension for dekformat.v0: if the architecture is Windows are any, w euse 'zip', else 'tar.gz'"
+  "default extension for dekformat.v0: if the architecture includes Windows, we use 'zip', else 'tar.gz'"
   (if (or (in "(Windows" rootname) (not (in "(" rootname))) ".zip" ".tar.gz"))
 
 ;; v1: all archives are ZIP-files with .dek extension

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -363,7 +363,7 @@
   (defn split-arch [arch fixdek0]
     (setv t (.split arch "-"))
     (if (and fixdek0 (> (len t) 2))
-        (assoc t 2 "32"))
+        (setv (get t 2) "32"))
     (tuple t))
   (if archstring
       (lfor x (re.findall r"\(([^()]*)\)" archstring) (split-arch x fixdek0))
@@ -393,7 +393,7 @@
   (setv others (lfor a archs :if (!= (len a) 3) (tuple a)))
   (setv archs  (lfor a archs :if ( = (len a) 3) (tuple a)))
   (setv archdict {})
-  (for [(, os cpu floatsize) archs] (assoc archdict (, os cpu) (.union (try-get archdict (, os cpu) (set)) [floatsize])))
+  (for [(, os cpu floatsize) archs] (setv (get archdict (, os cpu)) (.union (try-get archdict (, os cpu) (set)) [floatsize])))
   (.union (set (chain.from-iterable (lfor (, (, os cpu) floatsizes) (.items archdict) (lfor fs (or (list (filter bool floatsizes)) [0]) (, os cpu fs))))) others))
 
 ;; takes the externals architectures and turns them into a string)
@@ -902,7 +902,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   ;; returns a tuple (library, version, comparator)
   (setv result (try (get-values (re.split "(.+)([>=]=)(.+)" spec) [1 3 2])
                     (except [e IndexError] [spec None None])))
-  (assoc result 2 (try-get {"==" str.startswith ">=" >=} (get result 2) (fn [a b] True)))
+  (setv (get result 2) (try-get {"==" str.startswith ">=" >=} (get result 2) (fn [a b] True)))
   (tuple result))
 
 (defn make-requirement-matcher [parsedspec]
@@ -951,7 +951,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
       (do
         (setv pkgname (get lib "package"))
         (if (not (in pkgname pkgdict))
-            (assoc pkgdict pkgname []))
+            (setv (get pkgdict pkgname) []))
         (setv l (get pkgdict pkgname))
         (l.append lib)))
     ;; sort and truncate each dictvalue
@@ -1324,8 +1324,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
                "uploader" uploader
                "timestamp" date}
               (dict (zip ["package" "version" "architectures" "extension"] (parse-filename (or URL ""))))))
-      (assoc result
-             "architectures"
+      (setv (get result "architectures")
              (split-archstring
                (get result "architectures")
                (not (.endswith URL ".dek"))))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -184,6 +184,11 @@
        (except [e KeyError] default)
        (except [e IndexError] default)))
 
+(defn first [coll]
+  "Return first item from `coll`."
+  (for [f coll] (return f)))
+
+
 ;; replace multiple words (given as pairs in <repls>) in a string <s>
 (defn replace-words [s repls]
   "replace multiple words (given as pairs in <repls>) in a string <s>"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -973,7 +973,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
       (setv result
             (+ result (cut (sorted (get pkgdict key)
                                    :reverse True
-                                   :key (fn [d] (, (or (get d "version")) (or (get d "timestamp")))))
+                                   :key (fn [d] (, (or (get d "version") "") (or (get d "timestamp") ""))))
                            0 depth))))
     result)
   (if depth

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1652,7 +1652,7 @@ returns a tuple of a (list of verified files) and the number of failed verificat
            :verify-hash (and (not args.ignore-hash) (if (or args.ignore-missing args.ignore-missing-hash) None True))
            :verify-none args.no-verify
            :search-url  args.search-url) 1)))
-       :uninstall (fn [args] None
+       :uninstall (fn [args]
                     (if args.self
                         (fatal "self-'uninstall' not implemented for this platform!"))
                     (defn uninstall-pkgs [pkgs installdir]
@@ -1666,7 +1666,7 @@ returns a tuple of a (list of verified files) and the number of failed verificat
                             (log.warning (% "skipping non-existent directory '%s'" (, pkgdir))))))
                     (setv pkgs (--packages-from-args-- args.package args.requirement))
                     (uninstall-pkgs pkgs args.installdir))
-       :install (fn [args] None
+       :install (fn [args]
                   (if (and (not args.package) (not args.requirement))
                       (fatal "self-'install' not implemented for this platform!"))
                   (defn install-pkgs [pkgs installdir]
@@ -1707,7 +1707,7 @@ returns a tuple of a (list of verified files) and the number of failed verificat
                   )
        :systeminfo print-system-info
        ;; the rest should have been caught by the wrapper script
-       :systemfix (fn [args] None
+       :systemfix (fn [args]
                   (setv fixes {
                         :easywebdav2 (fn []
                                  (import easywebdav2)

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -917,7 +917,7 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   ;; <parsedspec> is the output of (parse-requirement): a (library, version, comparator) tuple
   ;; currently the only valid compatrators are ">=" and "=="
   ;; returns a tuple (library, version, comparator)
-                                ;(setv parsedspec (parse-requirement spec))
+  ; (setv parsedspec (parse-requirement spec))
   (setv package (get parsedspec 0))
   (setv version (get parsedspec 1))
   (setv compare (get parsedspec 2))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1701,7 +1701,9 @@ returns a tuple of a (list of verified files) and the number of failed verificat
                                    :verify-none args.no-verify
                                    :search-url args.search-url)
                           (, [] 0)))
-                  (install-pkgs (.union file-pkgs (set (get downloaded-pkgs 0))) args.installdir)
+                  (if (install-pkgs (.union file-pkgs (set (get downloaded-pkgs 0))) args.installdir)
+                      (not (get downloaded-pkgs 1))
+                    False)
                   )
        :systeminfo print-system-info
        ;; the rest should have been caught by the wrapper script

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -940,10 +940,10 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
   "creates a boolean function to check whether a given package-dict matches any of the given requirements"
   (if specs
       (fn [libdict] (any
-                      (lfor match (lfor spec specs
+                      (lfor req-match (lfor spec specs
                                         :if spec
                                         (make-requirement-matcher spec))
-                            (match libdict))))
+                            (req-match libdict))))
       (fn [libdict] True)))
 
 

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -146,7 +146,8 @@
 
 (defn str-to-bool [s]
   "convert a string into a bool, based on its value"
-  (and (not (is s None)) (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))))
+  (try (not (in (.lower s) ["false" "f" "no" "n" "0" "nil" "none"]))
+       (except [e AttributeError] (not (not s)))))
 
 (defn byte-to-int [b]
   "convert a single byte (e.g. an element of bytes()) into an integer"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -42,7 +42,7 @@
 (import datetime)
 (import logging)
 
-(import [configparser [ConfigParser :as SafeConfigParser]])
+(import [configparser [ConfigParser]])
 (import [io [StringIO]])
 (import [urllib.parse [urlparse]])
 
@@ -230,7 +230,7 @@
 
 
 ;; read in the config file if present
-(defn read-config [configstring &optional [config-file (SafeConfigParser)]]
+(defn read-config [configstring &optional [config-file (ConfigParser)]]
   "reads the configuration into a dictionary"
   (try (config-file.read_file (StringIO configstring))
        (except [e AttributeError] (config-file.readfp (StringIO configstring))))

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1917,12 +1917,12 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
     "--version"
     :action "version"
     :version version
-    :help "Outputs the version number of Deken.")
+    :help "Outputs the version number of Deken and exits.")
   (arg-parser.add_argument
     "--platform"
     :action "version"
     :version (.join "-" (native-arch))
-    :help "Outputs a guess of the current architecture.")
+    :help "Outputs a guess of the current architecture and exits.")
 
   (arg-package.add_argument
     "source"

--- a/developer/deken.hy
+++ b/developer/deken.hy
@@ -1500,9 +1500,14 @@ if the file does not exist or doesn't contain a 'DESCRIPTION', this returns 'DEK
           (except [e Exception] (log_debug e))))
     None)
   (defn try-download [url]
-    (setv pkg (download-file url))
-    (setv gpg (download-file (+ url ".asc")))
-    (setv hsh (download-file (+ url ".sha256")))
+    (defn --verbose-download-- [url msg]
+      (log.info msg)
+      (setv outfile (download-file url))
+      (if outfile (log.info "downloaded %s" outfile) (log.info "failed to download %s" url))
+      outfile)
+    (setv pkg (--verbose-download-- url "downloading package"))
+    (setv gpg (--verbose-download-- (+ url ".asc") "downloading GPG signature"))
+    (setv hsh (--verbose-download-- (+ url ".sha256") "downloading SHA256 hash"))
     (if (and
           (not (verify
                  pkg gpg hsh

--- a/developer/requirements.txt
+++ b/developer/requirements.txt
@@ -1,5 +1,4 @@
-hy~=1.0a4;python_version>="3.7"
-hy>=1.0a0;python_version<"3.7"
+hy~=1.0a4
 easywebdav2~=1.3
 pyelftools~=0.26
 macholib~=1.14

--- a/developer/requirements.txt
+++ b/developer/requirements.txt
@@ -1,4 +1,5 @@
-hy~=1.0a4
+hy~=1.0a4;python_version>="3.7"
+hy>=1.0a0;python_version<"3.7"
 easywebdav2~=1.3
 pyelftools~=0.26
 macholib~=1.14

--- a/developer/requirements.txt
+++ b/developer/requirements.txt
@@ -1,4 +1,4 @@
-hy~=0.19
+hy~=1.0a4
 easywebdav2~=1.3
 pyelftools~=0.26
 macholib~=1.14


### PR DESCRIPTION
This is an attempt to port the `deken` cmdline tool to hy-1.0

Closes: #259 

TODO:
- [x] `package`
- [x] `upload`
- [x] `find`
- [x] `download`
   - (downloading multiple times will fail, but this is not a regression))
- [x] `verify`
   - [x] sha256 verification failed (as a consequence, `download` etc also fail)
- [x] `install`
- [x] `uninstall`
- [x] `systeminfo`
   - fixed use of `match` (which has become a reserved token in Py3.10)
- [x] `systemfix`
   - fixed keyword<->string conversion
